### PR TITLE
feat(install): add ai-aware setup guidance

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -3,6 +3,7 @@ import { join } from 'pathe'
 import { useLogger } from '@nuxt/kit'
 import { createConsola } from 'consola'
 import { colorize } from 'consola/utils'
+import { agent, isAgent } from 'std-env'
 import type { Nuxt } from '@nuxt/schema'
 import { detectCurrentTarget, detectInstalledTargets, getSupportedTargets } from './agents'
 import { deriveSkillName, detectConflictingSkills, extractModuleSpecifier, discoverInstalledPackageFromSpecifier, formatConflictWarning, MANAGED_HINT_END, MANAGED_HINT_START, pathExists, resolveExportRoot } from './internal'
@@ -19,8 +20,62 @@ function isCancelled(value: unknown): boolean {
   return value === null || typeof value === 'symbol'
 }
 
+const AI_AGENT_TARGET_MAP: Record<string, string> = {
+  codex: 'codex',
+  claude: 'claude-code',
+  gemini: 'gemini-code-assist',
+  replit: 'replit-agent',
+}
+
+export interface AIGuidance {
+  intro: string
+  snippet: string
+  optionalFlags: string
+}
+
+export function resolveAIGuidanceTarget(currentTarget?: string, detectedAgent?: string): string | undefined {
+  if (currentTarget) {
+    return currentTarget
+  }
+
+  if (!detectedAgent) {
+    return undefined
+  }
+
+  return AI_AGENT_TARGET_MAP[detectedAgent]
+}
+
+export function buildAIGuidance(currentTarget?: string, detectedAgent?: string): AIGuidance {
+  const target = resolveAIGuidanceTarget(currentTarget, detectedAgent)
+  const sourceLabel = detectedAgent ? ` (${detectedAgent})` : ''
+  const snippetLines = [
+    'export default defineNuxtConfig({',
+    '  skillHub: {',
+    ...(target ? [`    targets: ['${target}'],`] : []),
+    `    generationMode: 'prepare',`,
+    '  },',
+    '})',
+  ]
+
+  return {
+    intro: `Install wizard skipped because nuxt-skill-hub was installed by an AI agent${sourceLabel}. Add this to your nuxt.config.ts:`,
+    snippet: snippetLines.join('\n'),
+    optionalFlags: target
+      ? 'Optional flags: set `skillHub.skillName`, enable `skillHub.moduleAuthoring`, or switch to `skillHub.generationMode: \'manual\'` if needed.'
+      : 'Optional flags: add `skillHub.targets` to pin an agent target, set `skillHub.skillName`, enable `skillHub.moduleAuthoring`, or switch to `skillHub.generationMode: \'manual\'` if needed.',
+  }
+}
+
 export async function runInstallWizard(nuxt: Nuxt): Promise<void> {
   const logger = useLogger('nuxt-skill-hub')
+
+  if (isAgent) {
+    const guidance = buildAIGuidance(detectCurrentTarget(), agent)
+    logger.info(guidance.intro)
+    logger.info(`\`\`\`ts\n${guidance.snippet}\n\`\`\``)
+    logger.info(guidance.optionalFlags)
+    return
+  }
 
   // Skip in CI or non-interactive environments
   if (process.env.CI || !process.stdout.isTTY) {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -96,6 +96,7 @@ describe('install wizard', () => {
 
   it('keeps the interactive wizard for human TTY installs', async () => {
     setTTY(true)
+    vi.stubEnv('CI', '')
     mockInstalledTargets = ['claude-code', 'codex']
     mockSupportedTargets = ['claude-code', 'codex']
     mockConsola.prompt

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let mockIsAgent = false
+let mockAgent: string | undefined
+let mockCurrentTarget: string | undefined
+let mockInstalledTargets: string[] = []
+let mockSupportedTargets: string[] = []
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+}
+
+const mockConsola = {
+  box: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  prompt: vi.fn(),
+  log: vi.fn(),
+  success: vi.fn(),
+}
+
+vi.mock('@nuxt/kit', () => ({
+  useLogger: () => mockLogger,
+}))
+
+vi.mock('consola', () => ({
+  createConsola: () => mockConsola,
+}))
+
+vi.mock('std-env', () => ({
+  get isAgent() {
+    return mockIsAgent
+  },
+  get agent() {
+    return mockAgent
+  },
+}))
+
+vi.mock('../src/agents', () => ({
+  detectCurrentTarget: () => mockCurrentTarget,
+  detectInstalledTargets: () => mockInstalledTargets,
+  getSupportedTargets: () => mockSupportedTargets,
+}))
+
+vi.mock('../src/internal', () => ({
+  deriveSkillName: vi.fn(async () => 'nuxt-test'),
+  detectConflictingSkills: vi.fn(() => []),
+  extractModuleSpecifier: vi.fn(() => undefined),
+  discoverInstalledPackageFromSpecifier: vi.fn(async () => null),
+  formatConflictWarning: vi.fn((value: string) => value),
+  MANAGED_HINT_END: '<!-- skill-hub:end -->',
+  MANAGED_HINT_START: '<!-- skill-hub:start -->',
+  pathExists: vi.fn(async () => false),
+  resolveExportRoot: vi.fn(async () => '/repo'),
+}))
+
+const { buildAIGuidance, runInstallWizard } = await import('../src/install')
+
+const baseNuxt = {
+  options: {
+    rootDir: '/repo',
+    modules: [],
+  },
+}
+
+let originalStdoutTTY: PropertyDescriptor | undefined
+
+function setTTY(value: boolean) {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value,
+  })
+}
+
+describe('install wizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    mockIsAgent = false
+    mockAgent = undefined
+    mockCurrentTarget = undefined
+    mockInstalledTargets = []
+    mockSupportedTargets = []
+    originalStdoutTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  })
+
+  afterEach(() => {
+    if (originalStdoutTTY) {
+      Object.defineProperty(process.stdout, 'isTTY', originalStdoutTTY)
+    }
+    else {
+      Reflect.deleteProperty(process.stdout, 'isTTY')
+    }
+  })
+
+  it('keeps the interactive wizard for human TTY installs', async () => {
+    setTTY(true)
+    mockInstalledTargets = ['claude-code', 'codex']
+    mockSupportedTargets = ['claude-code', 'codex']
+    mockConsola.prompt
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce('skip')
+
+    await runInstallWizard(baseNuxt as never)
+
+    expect(mockConsola.prompt).toHaveBeenCalledTimes(2)
+    expect(mockLogger.info).not.toHaveBeenCalledWith(expect.stringContaining('Install wizard skipped because nuxt-skill-hub was installed by an AI agent'))
+  })
+
+  it('prints codex guidance without prompting', async () => {
+    setTTY(false)
+    mockIsAgent = true
+    mockAgent = 'codex'
+
+    await runInstallWizard(baseNuxt as never)
+
+    const logged = mockLogger.info.mock.calls.map(call => call[0]).join('\n')
+    expect(mockConsola.prompt).not.toHaveBeenCalled()
+    expect(logged).toContain('installed by an AI agent (codex)')
+    expect(logged).toContain('targets: [\'codex\']')
+    expect(logged).toContain('generationMode: \'prepare\'')
+  })
+
+  it('prints claude guidance without prompting', async () => {
+    setTTY(false)
+    mockIsAgent = true
+    mockAgent = 'claude'
+
+    await runInstallWizard(baseNuxt as never)
+
+    const logged = mockLogger.info.mock.calls.map(call => call[0]).join('\n')
+    expect(mockConsola.prompt).not.toHaveBeenCalled()
+    expect(logged).toContain('targets: [\'claude-code\']')
+    expect(logged).toContain('generationMode: \'prepare\'')
+  })
+
+  it('omits targets for unmapped agents and explains explicit targets can be added later', async () => {
+    setTTY(false)
+    mockIsAgent = true
+    mockAgent = 'auggie'
+
+    await runInstallWizard(baseNuxt as never)
+
+    const logged = mockLogger.info.mock.calls.map(call => call[0]).join('\n')
+    expect(mockConsola.prompt).not.toHaveBeenCalled()
+    expect(logged).not.toContain('targets:')
+    expect(logged).toContain('add `skillHub.targets` to pin an agent target')
+    expect(logged).toContain('generationMode: \'prepare\'')
+  })
+
+  it('prefers detectCurrentTarget over std-env agent mapping', () => {
+    expect(buildAIGuidance('codex', 'claude').snippet).toContain('targets: [\'codex\']')
+  })
+
+  it('keeps the existing non-interactive skip for non-agent installs', async () => {
+    setTTY(false)
+
+    await runInstallWizard(baseNuxt as never)
+
+    expect(mockConsola.prompt).not.toHaveBeenCalled()
+    expect(mockLogger.info).toHaveBeenCalledWith('Non-interactive environment detected, skipping install wizard.')
+  })
+})


### PR DESCRIPTION
## Summary
- skip the interactive install wizard when nuxt-skill-hub is installed by an AI agent
- print AI-specific nuxt.config.ts guidance with recommended skillHub options
- add unit tests for AI, human TTY, and non-interactive install behavior

## Testing
- pnpm eslint src/install.ts test/install.test.ts
- pnpm vitest run test/install.test.ts test/module-setup.test.ts