### PR TITLE
feat: eslint rule to remove redundant imports

### DIFF
--- a/docs/app/components/DocsSection.vue
+++ b/docs/app/components/DocsSection.vue
@@ -13,6 +13,7 @@ const options: Option[] = [
   { name: 'targets', type: 'SkillHubTarget[]', default: '[]', description: 'Optional explicit agent targets. Leave empty to auto-detect installed agents.' },
   { name: 'moduleAuthoring', type: 'boolean', default: 'false', description: 'Adds module-author guidance on top of the default Nuxt app skill.' },
   { name: 'generationMode', type: '\'prepare\' | \'manual\'', default: 'prepare', description: 'Controls when the full generated skill tree is refreshed inside Nuxt buildDir.' },
+  { name: 'eslint', type: 'boolean', default: 'true', description: 'Auto-registers the redundant auto-import rule when @nuxt/eslint is installed. Set to false to opt out.' },
 ]
 
 const expandedRow = ref<number | null>(null)
@@ -25,6 +26,7 @@ const configCode = `modules: ['nuxt-skill-hub'],
   skillHub: {
     targets: ['claude-code'],
     generationMode: 'prepare',
+    eslint: false,
   }
 `
 
@@ -38,7 +40,7 @@ const { copy, copied } = useClipboard({ copiedDuring: 2000 })
         <p class="mb-3 font-mono text-xs font-medium uppercase tracking-widest text-primary">Configuration</p>
         <h2 class="text-3xl font-bold text-highlighted sm:text-4xl">Configure it when you need control</h2>
         <p class="mt-4 text-lg text-muted leading-relaxed">
-          Most projects work with the defaults. Configure <code class="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-sm text-primary">skillHub</code> in <code class="rounded bg-muted/20 px-1.5 py-0.5 font-mono text-sm text-highlighted">nuxt.config.ts</code> when you need a custom skill name, explicit agent targets, extra module-author guidance, or a different generation policy.
+          Most projects work with the defaults. Configure <code class="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-sm text-primary">skillHub</code> in <code class="rounded bg-muted/20 px-1.5 py-0.5 font-mono text-sm text-highlighted">nuxt.config.ts</code> when you need a custom skill name, explicit agent targets, extra module-author guidance, a different generation policy, or to opt out of the ESLint redundant-import rule.
         </p>
       </div>
 
@@ -122,6 +124,7 @@ const { copy, copied } = useClipboard({ copiedDuring: 2000 })
   <span class="text-primary">skillHub</span>: {
     <span class="text-highlighted">targets</span>: [<span class="text-emerald-500 dark:text-emerald-400">'claude-code'</span>],
     <span class="text-highlighted">generationMode</span>: <span class="text-emerald-500 dark:text-emerald-400">'prepare'</span>,
+    <span class="text-highlighted">eslint</span>: <span class="text-rose-500 dark:text-rose-400">false</span>,
   }
 <span class="opacity-45">})</span></pre>
           </div>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
       "types": "./dist/types.d.mts",
       "import": "./dist/module.mjs",
       "default": "./dist/module.mjs"
+    },
+    "./eslint-plugin": {
+      "import": "./dist/runtime/eslint/plugin.js"
     }
   },
   "main": "./dist/module.mjs",

--- a/package.json
+++ b/package.json
@@ -40,18 +40,18 @@
   },
   "dependencies": {
     "@nuxt/kit": "^4.3.1",
-    "automd": "catalog:runtime",
+    "automd": "^0.4.3",
     "consola": "^3.4.0",
     "giget": "^3.1.2",
     "gray-matter": "^4.0.3",
-    "mlly": "catalog:runtime",
+    "mlly": "^1.8.1",
     "ofetch": "^1.5.0",
     "ohash": "^2.0.11",
     "pathe": "^2.0.0",
     "pkg-types": "^2.3.0",
     "std-env": "^4.0.0",
     "tinyglobby": "^0.2.15",
-    "unagent": "catalog:runtime"
+    "unagent": "^0.0.8"
   },
   "devDependencies": {
     "@nuxt/devtools": "catalog:nuxt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,16 +60,6 @@ catalogs:
     bumpp:
       specifier: ^10.4.1
       version: 10.4.1
-  runtime:
-    automd:
-      specifier: ^0.4.3
-      version: 0.4.3
-    mlly:
-      specifier: ^1.8.1
-      version: 1.8.1
-    unagent:
-      specifier: ^0.0.8
-      version: 0.0.8
 
 importers:
 
@@ -79,7 +69,7 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1(magicast@0.5.2)
       automd:
-        specifier: catalog:runtime
+        specifier: ^0.4.3
         version: 0.4.3(magicast@0.5.2)
       consola:
         specifier: ^3.4.0
@@ -91,7 +81,7 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       mlly:
-        specifier: catalog:runtime
+        specifier: ^1.8.1
         version: 1.8.1
       ofetch:
         specifier: ^1.5.0
@@ -112,7 +102,7 @@ importers:
         specifier: ^0.2.15
         version: 0.2.15
       unagent:
-        specifier: catalog:runtime
+        specifier: ^0.0.8
         version: 0.0.8(pg@8.18.0)(unstorage@1.17.4(db0@0.3.4(@electric-sql/pglite@0.3.15)(drizzle-orm@0.41.0(@cloudflare/workers-types@4.20260304.0)(@electric-sql/pglite@0.3.15)(@prisma/client@5.22.0(prisma@7.4.1(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(@types/pg@8.16.0)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.18.0)(postgres@3.4.7)(prisma@7.4.1(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(mysql2@3.15.3))(ioredis@5.9.3))
     devDependencies:
       '@nuxt/devtools':

--- a/src/eslint/addon.ts
+++ b/src/eslint/addon.ts
@@ -11,16 +11,17 @@ interface ESLintConfigGenAddon {
 export function createAutoImportAddon(nuxt: Nuxt): void {
   let unimport: UnimportLike | undefined
   let nitroUnimport: UnimportLike | undefined
+  const hook = nuxt.hook as unknown as <T extends unknown[]>(name: string, callback: (...args: T) => void) => void
 
-  nuxt.hook('imports:context', (context) => {
+  hook('imports:context', (context: UnimportLike) => {
     unimport = context as UnimportLike
   })
 
-  nuxt.hook('nitro:init', (nitro) => {
-    nitroUnimport = (nitro as unknown as { unimport?: UnimportLike }).unimport
+  hook('nitro:init', (nitro: { unimport?: UnimportLike }) => {
+    nitroUnimport = nitro.unimport
   })
 
-  nuxt.hook('eslint:config:addons' as 'app:created', (addons: ESLintConfigGenAddon[]) => {
+  hook('eslint:config:addons', (addons: ESLintConfigGenAddon[]) => {
     addons.push({
       name: 'skill-hub:no-redundant-import',
       async getConfigs() {

--- a/src/eslint/addon.ts
+++ b/src/eslint/addon.ts
@@ -33,7 +33,7 @@ export function createAutoImportAddon(nuxt: Nuxt): void {
         const seen = new Set<string>()
         const entries = imports
           .filter((i) => {
-            const key = `${i.as || i.name}:${i.from}`
+            const key = `${i.as || i.name}:${i.from}:${i.type ? 'type' : 'value'}`
             if (seen.has(key)) return false
             seen.add(key)
             return true

--- a/src/eslint/addon.ts
+++ b/src/eslint/addon.ts
@@ -1,0 +1,59 @@
+import type { Nuxt } from '@nuxt/schema'
+
+interface ImportEntry { name: string, as?: string, from: string, type?: boolean }
+interface UnimportLike { getImports: () => Promise<ImportEntry[]> }
+
+interface ESLintConfigGenAddon {
+  name: string
+  getConfigs: () => Promise<{ imports?: { from: string, name: string, as?: string }[], configs?: string[] } | undefined>
+}
+
+export function createAutoImportAddon(nuxt: Nuxt): void {
+  let unimport: UnimportLike | undefined
+  let nitroUnimport: UnimportLike | undefined
+
+  nuxt.hook('imports:context', (context) => {
+    unimport = context as UnimportLike
+  })
+
+  nuxt.hook('nitro:init', (nitro) => {
+    nitroUnimport = (nitro as unknown as { unimport?: UnimportLike }).unimport
+  })
+
+  nuxt.hook('eslint:config:addons' as 'app:created', (addons: ESLintConfigGenAddon[]) => {
+    addons.push({
+      name: 'skill-hub:no-redundant-import',
+      async getConfigs() {
+        const imports: ImportEntry[] = [
+          ...await unimport?.getImports() || [],
+          ...await nitroUnimport?.getImports() || [],
+        ]
+
+        const seen = new Set<string>()
+        const entries = imports
+          .filter((i) => {
+            const key = `${i.as || i.name}:${i.from}`
+            if (seen.has(key)) return false
+            seen.add(key)
+            return true
+          })
+          .map(i => ({ name: i.name, ...(i.as && i.as !== i.name ? { as: i.as } : {}), from: i.from, ...(i.type ? { type: true } : {}) }))
+          .sort((a, b) => a.from.localeCompare(b.from) || a.name.localeCompare(b.name))
+
+        return {
+          imports: [{ from: 'nuxt-skill-hub/eslint-plugin', name: 'default', as: 'skillHubPlugin' }],
+          configs: [
+            [
+              '{',
+              `  name: 'skill-hub/no-redundant-import',`,
+              `  plugins: { 'skill-hub': skillHubPlugin },`,
+              `  settings: { 'skill-hub/autoImports': ${JSON.stringify(entries)} },`,
+              `  rules: { 'skill-hub/no-redundant-import': 'warn' },`,
+              '}',
+            ].join('\n'),
+          ],
+        }
+      },
+    })
+  })
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,6 +5,7 @@ import { resolveExportRoot, deriveSkillName, detectConflictingSkills, formatConf
 import { PACKAGE_VERSION } from './package-info'
 import { runInstallWizard } from './install'
 import { DEFAULT_SKILL_HUB_GENERATION_MODE, normalizeGenerationMode } from './types'
+import { createAutoImportAddon } from './eslint/addon'
 import type { ModuleOptions, SkillHubContributionContext } from './types'
 
 export default defineNuxtModule<ModuleOptions>({
@@ -27,6 +28,9 @@ export default defineNuxtModule<ModuleOptions>({
   },
   async setup(options, nuxt) {
     const logger = useLogger('nuxt-skill-hub')
+
+    if (options.eslint !== false)
+      createAutoImportAddon(nuxt)
 
     if (isCI && !isTest) {
       logger.info('Skipping skill generation in CI')

--- a/src/runtime/eslint/no-redundant-import.ts
+++ b/src/runtime/eslint/no-redundant-import.ts
@@ -1,0 +1,120 @@
+import type { Rule } from 'eslint'
+
+interface AutoImportEntry {
+  name: string
+  as?: string
+  from: string
+  type?: boolean
+}
+
+interface SpecInfo { spec: Rule.Node, importedName: string, localName: string, isRedundant: boolean }
+
+type ImportSpecifier = Rule.Node & { imported: { type: string, name: string, value?: string }, local: { name: string }, importKind?: string }
+type ImportDeclaration = Rule.Node & { source: { value: string }, specifiers: ImportSpecifier[], importKind?: string }
+
+const SETTINGS_KEY = 'skill-hub/autoImports'
+
+export const noRedundantImport: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow explicit imports of auto-imported identifiers in Nuxt',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      redundant: '\'{{ name }}\' is auto-imported by Nuxt. Remove this explicit import.',
+    },
+  },
+  create(context) {
+    const entries = context.settings[SETTINGS_KEY] as AutoImportEntry[] | undefined
+    if (!entries?.length)
+      return {}
+
+    // Build lookup: source -> Set<name>
+    const lookup = new Map<string, Set<string>>()
+    for (const entry of entries) {
+      const name = entry.as || entry.name
+      const existing = lookup.get(entry.from)
+      if (existing) existing.add(name)
+      else lookup.set(entry.from, new Set([name]))
+    }
+
+    return {
+      ImportDeclaration(node: ImportDeclaration) {
+        if (!node.specifiers.length) return
+
+        const source = node.source.value
+        const autoImported = lookup.get(source)
+        if (!autoImported) return
+
+        if (context.filename.endsWith('.d.ts')) return
+
+        const specInfos: SpecInfo[] = []
+
+        for (const spec of node.specifiers) {
+          if (spec.type !== 'ImportSpecifier') {
+            specInfos.push({ spec, importedName: '', localName: '', isRedundant: false })
+            continue
+          }
+
+          const importedName = spec.imported.type === 'Identifier' ? spec.imported.name : (spec.imported.value ?? '')
+          const localName = spec.local.name
+
+          const isAliased = importedName !== localName
+          const isRedundant = !isAliased && autoImported.has(importedName)
+
+          specInfos.push({ spec, importedName, localName, isRedundant })
+        }
+
+        const redundant = specInfos.filter(s => s.isRedundant)
+        if (!redundant.length) return
+
+        const kept = specInfos.filter(s => !s.isRedundant)
+        const sourceText = context.sourceCode.getText()
+
+        // All specifiers redundant → remove entire statement
+        if (!kept.length) {
+          context.report({
+            node,
+            messageId: 'redundant',
+            data: { name: redundant.map(s => s.importedName).join(', ') },
+            fix: fixer => fixer.removeRange([node.range![0], nextLineStart(sourceText, node.range![1])]),
+          })
+          return
+        }
+
+        // Partial removal → rebuild the specifiers portion
+        context.report({
+          node,
+          messageId: 'redundant',
+          data: { name: redundant.map(s => s.importedName).join(', ') },
+          fix(fixer) {
+            const keptTexts = kept.map(s => context.sourceCode.getText(s.spec))
+            const importText = context.sourceCode.getText(node)
+            const braceStart = node.range![0] + importText.indexOf('{')
+            const braceEnd = node.range![0] + importText.lastIndexOf('}') + 1
+
+            // If remaining specifiers are all inline `type` → convert to `import type`
+            const isStatementTypeImport = node.importKind === 'type'
+            const allKeptAreTypeSpecifiers = !isStatementTypeImport && kept.every(s => (s.spec as ImportSpecifier).importKind === 'type')
+
+            if (allKeptAreTypeSpecifiers) {
+              const cleanedTexts = keptTexts.map(t => t.replace(/^type\s+/, ''))
+              const newSpecifiers = `{ ${cleanedTexts.join(', ')} }`
+              const importKeywordEnd = node.range![0] + 'import'.length
+              return fixer.replaceTextRange([importKeywordEnd, braceEnd], ` type ${newSpecifiers}`)
+            }
+
+            return fixer.replaceTextRange([braceStart, braceEnd], `{ ${keptTexts.join(', ')} }`)
+          },
+        })
+      },
+    }
+  },
+}
+
+function nextLineStart(text: string, pos: number): number {
+  const nl = text.indexOf('\n', pos)
+  return nl === -1 ? pos : nl + 1
+}

--- a/src/runtime/eslint/no-redundant-import.ts
+++ b/src/runtime/eslint/no-redundant-import.ts
@@ -7,11 +7,20 @@ interface AutoImportEntry {
   type?: boolean
 }
 
-interface SpecInfo { spec: Rule.Node, localName: string, isRedundant: boolean }
-interface SourceLookup { type: Set<string>, value: Set<string> }
+type ImportSourceNode = Rule.Node & { value: string, range: [number, number] }
+type ImportSpecifierNode = Rule.Node & { type: 'ImportSpecifier', local: { name: string }, importKind?: 'type' | 'value' }
+type ImportDefaultSpecifierNode = Rule.Node & { type: 'ImportDefaultSpecifier' }
+type ImportNamespaceSpecifierNode = Rule.Node & { type: 'ImportNamespaceSpecifier' }
+type ImportNode = Rule.Node & {
+  type: 'ImportDeclaration'
+  importKind?: 'type' | 'value'
+  range: [number, number]
+  source: ImportSourceNode
+  specifiers: Array<ImportDefaultSpecifierNode | ImportNamespaceSpecifierNode | ImportSpecifierNode>
+}
 
-type ImportSpecifier = Rule.Node & { imported: { type: string, name: string, value?: string }, local: { name: string }, importKind?: string }
-type ImportDeclaration = Rule.Node & { source: { value: string }, specifiers: ImportSpecifier[], importKind?: string }
+interface SpecInfo { spec: ImportNode['specifiers'][number], localName: string, isRedundant: boolean }
+interface SourceLookup { type: Set<string>, value: Set<string> }
 
 const SETTINGS_KEY = 'skill-hub/autoImports'
 
@@ -27,7 +36,7 @@ export const noRedundantImport: Rule.RuleModule = {
       redundant: '\'{{ name }}\' is auto-imported by Nuxt. Remove this explicit import.',
     },
   },
-  create(context) {
+  create(context): Rule.RuleListener {
     const entries = context.settings[SETTINGS_KEY] as AutoImportEntry[] | undefined
     if (!entries?.length)
       return {}
@@ -41,10 +50,12 @@ export const noRedundantImport: Rule.RuleModule = {
     }
 
     return {
-      ImportDeclaration(node: ImportDeclaration) {
-        if (!node.specifiers.length) return
+      ImportDeclaration(node) {
+        const importNode = node as unknown as ImportNode
+        if (!importNode.specifiers.length) return
 
-        const source = node.source.value
+        const source = typeof importNode.source.value === 'string' ? importNode.source.value : undefined
+        if (!source) return
         const autoImported = lookup.get(source)
         if (!autoImported) return
 
@@ -52,14 +63,14 @@ export const noRedundantImport: Rule.RuleModule = {
 
         const specInfos: SpecInfo[] = []
 
-        for (const spec of node.specifiers) {
+        for (const spec of importNode.specifiers) {
           if (spec.type !== 'ImportSpecifier') {
             specInfos.push({ spec, localName: '', isRedundant: false })
             continue
           }
 
           const localName = spec.local.name
-          const names = isTypeOnlyImport(node, spec) ? autoImported.type : autoImported.value
+          const names = isTypeOnlyImport(importNode, spec) ? autoImported.type : autoImported.value
           specInfos.push({ spec, localName, isRedundant: names.has(localName) })
         }
 
@@ -72,19 +83,19 @@ export const noRedundantImport: Rule.RuleModule = {
         // All specifiers redundant → remove entire statement
         if (!kept.length) {
           context.report({
-            node,
+            node: importNode,
             messageId: 'redundant',
             data: { name: redundant.map(s => s.localName).join(', ') },
-            fix: fixer => fixer.removeRange([node.range![0], nextLineStart(sourceText, node.range![1])]),
+            fix: fixer => fixer.removeRange([importNode.range[0], nextLineStart(sourceText, importNode.range[1])]),
           })
           return
         }
 
         context.report({
-          node,
+          node: importNode,
           messageId: 'redundant',
           data: { name: redundant.map(s => s.localName).join(', ') },
-          fix: fixer => fixer.replaceText(node, rebuildImportDeclaration(context, node, kept)),
+          fix: fixer => fixer.replaceText(importNode, rebuildImportDeclaration(context, importNode, kept)),
         })
       },
     }
@@ -96,14 +107,14 @@ function nextLineStart(text: string, pos: number): number {
   return nl === -1 ? pos : nl + 1
 }
 
-function isTypeOnlyImport(node: ImportDeclaration, spec: ImportSpecifier): boolean {
+function isTypeOnlyImport(node: ImportNode, spec: ImportSpecifierNode): boolean {
   return node.importKind === 'type' || spec.importKind === 'type'
 }
 
-function rebuildImportDeclaration(context: Rule.RuleContext, node: ImportDeclaration, kept: SpecInfo[]): string {
+function rebuildImportDeclaration(context: Rule.RuleContext, node: ImportNode, kept: SpecInfo[]): string {
   const defaultSpecifiers = kept.filter(({ spec }) => spec.type === 'ImportDefaultSpecifier')
   const namespaceSpecifiers = kept.filter(({ spec }) => spec.type === 'ImportNamespaceSpecifier')
-  const namedSpecifiers = kept.filter(({ spec }) => spec.type === 'ImportSpecifier').map(({ spec }) => spec as ImportSpecifier)
+  const namedSpecifiers = kept.filter(({ spec }) => spec.type === 'ImportSpecifier').map(({ spec }) => spec as ImportSpecifierNode)
   const useTypeKeyword = node.importKind !== 'type'
     && !defaultSpecifiers.length
     && !namespaceSpecifiers.length
@@ -123,6 +134,7 @@ function rebuildImportDeclaration(context: Rule.RuleContext, node: ImportDeclara
     specifierTexts.push(`{ ${namedTexts.join(', ')} }`)
   }
 
-  const suffix = context.sourceCode.text.slice(node.source.range![1], node.range![1])
+  const sourceRange = node.source.range as [number, number]
+  const suffix = context.sourceCode.text.slice(sourceRange[1], node.range[1])
   return `import${node.importKind === 'type' || useTypeKeyword ? ' type' : ''} ${specifierTexts.join(', ')} from ${context.sourceCode.getText(node.source)}${suffix}`
 }

--- a/src/runtime/eslint/no-redundant-import.ts
+++ b/src/runtime/eslint/no-redundant-import.ts
@@ -7,7 +7,8 @@ interface AutoImportEntry {
   type?: boolean
 }
 
-interface SpecInfo { spec: Rule.Node, importedName: string, localName: string, isRedundant: boolean }
+interface SpecInfo { spec: Rule.Node, localName: string, isRedundant: boolean }
+interface SourceLookup { type: Set<string>, value: Set<string> }
 
 type ImportSpecifier = Rule.Node & { imported: { type: string, name: string, value?: string }, local: { name: string }, importKind?: string }
 type ImportDeclaration = Rule.Node & { source: { value: string }, specifiers: ImportSpecifier[], importKind?: string }
@@ -31,13 +32,12 @@ export const noRedundantImport: Rule.RuleModule = {
     if (!entries?.length)
       return {}
 
-    // Build lookup: source -> Set<name>
-    const lookup = new Map<string, Set<string>>()
+    const lookup = new Map<string, SourceLookup>()
     for (const entry of entries) {
-      const name = entry.as || entry.name
-      const existing = lookup.get(entry.from)
-      if (existing) existing.add(name)
-      else lookup.set(entry.from, new Set([name]))
+      const localName = entry.as || entry.name
+      const existing = lookup.get(entry.from) || { type: new Set<string>(), value: new Set<string>() }
+      existing[entry.type ? 'type' : 'value'].add(localName)
+      lookup.set(entry.from, existing)
     }
 
     return {
@@ -54,17 +54,13 @@ export const noRedundantImport: Rule.RuleModule = {
 
         for (const spec of node.specifiers) {
           if (spec.type !== 'ImportSpecifier') {
-            specInfos.push({ spec, importedName: '', localName: '', isRedundant: false })
+            specInfos.push({ spec, localName: '', isRedundant: false })
             continue
           }
 
-          const importedName = spec.imported.type === 'Identifier' ? spec.imported.name : (spec.imported.value ?? '')
           const localName = spec.local.name
-
-          const isAliased = importedName !== localName
-          const isRedundant = !isAliased && autoImported.has(importedName)
-
-          specInfos.push({ spec, importedName, localName, isRedundant })
+          const names = isTypeOnlyImport(node, spec) ? autoImported.type : autoImported.value
+          specInfos.push({ spec, localName, isRedundant: names.has(localName) })
         }
 
         const redundant = specInfos.filter(s => s.isRedundant)
@@ -78,36 +74,17 @@ export const noRedundantImport: Rule.RuleModule = {
           context.report({
             node,
             messageId: 'redundant',
-            data: { name: redundant.map(s => s.importedName).join(', ') },
+            data: { name: redundant.map(s => s.localName).join(', ') },
             fix: fixer => fixer.removeRange([node.range![0], nextLineStart(sourceText, node.range![1])]),
           })
           return
         }
 
-        // Partial removal → rebuild the specifiers portion
         context.report({
           node,
           messageId: 'redundant',
-          data: { name: redundant.map(s => s.importedName).join(', ') },
-          fix(fixer) {
-            const keptTexts = kept.map(s => context.sourceCode.getText(s.spec))
-            const importText = context.sourceCode.getText(node)
-            const braceStart = node.range![0] + importText.indexOf('{')
-            const braceEnd = node.range![0] + importText.lastIndexOf('}') + 1
-
-            // If remaining specifiers are all inline `type` → convert to `import type`
-            const isStatementTypeImport = node.importKind === 'type'
-            const allKeptAreTypeSpecifiers = !isStatementTypeImport && kept.every(s => (s.spec as ImportSpecifier).importKind === 'type')
-
-            if (allKeptAreTypeSpecifiers) {
-              const cleanedTexts = keptTexts.map(t => t.replace(/^type\s+/, ''))
-              const newSpecifiers = `{ ${cleanedTexts.join(', ')} }`
-              const importKeywordEnd = node.range![0] + 'import'.length
-              return fixer.replaceTextRange([importKeywordEnd, braceEnd], ` type ${newSpecifiers}`)
-            }
-
-            return fixer.replaceTextRange([braceStart, braceEnd], `{ ${keptTexts.join(', ')} }`)
-          },
+          data: { name: redundant.map(s => s.localName).join(', ') },
+          fix: fixer => fixer.replaceText(node, rebuildImportDeclaration(context, node, kept)),
         })
       },
     }
@@ -117,4 +94,35 @@ export const noRedundantImport: Rule.RuleModule = {
 function nextLineStart(text: string, pos: number): number {
   const nl = text.indexOf('\n', pos)
   return nl === -1 ? pos : nl + 1
+}
+
+function isTypeOnlyImport(node: ImportDeclaration, spec: ImportSpecifier): boolean {
+  return node.importKind === 'type' || spec.importKind === 'type'
+}
+
+function rebuildImportDeclaration(context: Rule.RuleContext, node: ImportDeclaration, kept: SpecInfo[]): string {
+  const defaultSpecifiers = kept.filter(({ spec }) => spec.type === 'ImportDefaultSpecifier')
+  const namespaceSpecifiers = kept.filter(({ spec }) => spec.type === 'ImportNamespaceSpecifier')
+  const namedSpecifiers = kept.filter(({ spec }) => spec.type === 'ImportSpecifier').map(({ spec }) => spec as ImportSpecifier)
+  const useTypeKeyword = node.importKind !== 'type'
+    && !defaultSpecifiers.length
+    && !namespaceSpecifiers.length
+    && namedSpecifiers.length > 0
+    && namedSpecifiers.every(spec => spec.importKind === 'type')
+
+  const specifierTexts = [
+    ...defaultSpecifiers.map(({ spec }) => context.sourceCode.getText(spec)),
+    ...namespaceSpecifiers.map(({ spec }) => context.sourceCode.getText(spec)),
+  ]
+
+  if (namedSpecifiers.length) {
+    const namedTexts = namedSpecifiers.map((spec) => {
+      const text = context.sourceCode.getText(spec)
+      return useTypeKeyword ? text.replace(/^type\s+/, '') : text
+    })
+    specifierTexts.push(`{ ${namedTexts.join(', ')} }`)
+  }
+
+  const suffix = context.sourceCode.text.slice(node.source.range![1], node.range![1])
+  return `import${node.importKind === 'type' || useTypeKeyword ? ' type' : ''} ${specifierTexts.join(', ')} from ${context.sourceCode.getText(node.source)}${suffix}`
 }

--- a/src/runtime/eslint/no-redundant-import.ts
+++ b/src/runtime/eslint/no-redundant-import.ts
@@ -8,7 +8,12 @@ interface AutoImportEntry {
 }
 
 type ImportSourceNode = Rule.Node & { value: string, range: [number, number] }
-type ImportSpecifierNode = Rule.Node & { type: 'ImportSpecifier', local: { name: string }, importKind?: 'type' | 'value' }
+type ImportSpecifierNode = Rule.Node & {
+  type: 'ImportSpecifier'
+  imported: { name?: string, value?: string }
+  local: { name: string }
+  importKind?: 'type' | 'value'
+}
 type ImportDefaultSpecifierNode = Rule.Node & { type: 'ImportDefaultSpecifier' }
 type ImportNamespaceSpecifierNode = Rule.Node & { type: 'ImportNamespaceSpecifier' }
 type ImportNode = Rule.Node & {
@@ -20,7 +25,8 @@ type ImportNode = Rule.Node & {
 }
 
 interface SpecInfo { spec: ImportNode['specifiers'][number], localName: string, isRedundant: boolean }
-interface SourceLookup { type: Set<string>, value: Set<string> }
+type AutoImportNames = Map<string, Set<string>>
+interface SourceLookup { type: AutoImportNames, value: AutoImportNames }
 
 const SETTINGS_KEY = 'skill-hub/autoImports'
 
@@ -44,8 +50,8 @@ export const noRedundantImport: Rule.RuleModule = {
     const lookup = new Map<string, SourceLookup>()
     for (const entry of entries) {
       const localName = entry.as || entry.name
-      const existing = lookup.get(entry.from) || { type: new Set<string>(), value: new Set<string>() }
-      existing[entry.type ? 'type' : 'value'].add(localName)
+      const existing = lookup.get(entry.from) || { type: new Map(), value: new Map() }
+      addAutoImportName(existing[entry.type ? 'type' : 'value'], localName, entry.name)
       lookup.set(entry.from, existing)
     }
 
@@ -71,7 +77,8 @@ export const noRedundantImport: Rule.RuleModule = {
 
           const localName = spec.local.name
           const names = isTypeOnlyImport(importNode, spec) ? autoImported.type : autoImported.value
-          specInfos.push({ spec, localName, isRedundant: names.has(localName) })
+          const importedName = getImportedName(spec)
+          specInfos.push({ spec, localName, isRedundant: importedName ? names.get(localName)?.has(importedName) === true : false })
         }
 
         const redundant = specInfos.filter(s => s.isRedundant)
@@ -126,6 +133,20 @@ function importRemovalRange(text: string, range: [number, number]): [number, num
 
 function isTypeOnlyImport(node: ImportNode, spec: ImportSpecifierNode): boolean {
   return node.importKind === 'type' || spec.importKind === 'type'
+}
+
+function addAutoImportName(lookup: AutoImportNames, localName: string, importedName: string): void {
+  const importedNames = lookup.get(localName) || new Set<string>()
+  importedNames.add(importedName)
+  lookup.set(localName, importedNames)
+}
+
+function getImportedName(spec: ImportSpecifierNode): string | undefined {
+  return typeof spec.imported.name === 'string'
+    ? spec.imported.name
+    : typeof spec.imported.value === 'string'
+      ? spec.imported.value
+      : undefined
 }
 
 function rebuildImportDeclaration(context: Rule.RuleContext, node: ImportNode, kept: SpecInfo[]): string {

--- a/src/runtime/eslint/no-redundant-import.ts
+++ b/src/runtime/eslint/no-redundant-import.ts
@@ -59,7 +59,7 @@ export const noRedundantImport: Rule.RuleModule = {
         const autoImported = lookup.get(source)
         if (!autoImported) return
 
-        if (context.filename.endsWith('.d.ts')) return
+        if (isDeclarationFile(context.filename)) return
 
         const specInfos: SpecInfo[] = []
 
@@ -86,7 +86,7 @@ export const noRedundantImport: Rule.RuleModule = {
             node: importNode,
             messageId: 'redundant',
             data: { name: redundant.map(s => s.localName).join(', ') },
-            fix: fixer => fixer.removeRange([importNode.range[0], nextLineStart(sourceText, importNode.range[1])]),
+            fix: fixer => fixer.removeRange(importRemovalRange(sourceText, importNode.range)),
           })
           return
         }
@@ -102,9 +102,26 @@ export const noRedundantImport: Rule.RuleModule = {
   },
 }
 
-function nextLineStart(text: string, pos: number): number {
-  const nl = text.indexOf('\n', pos)
-  return nl === -1 ? pos : nl + 1
+function isDeclarationFile(filename: string): boolean {
+  return /\.d\.(?:cts|mts|ts)$/.test(filename)
+}
+
+function importRemovalRange(text: string, range: [number, number]): [number, number] {
+  let end = range[1]
+
+  while (text[end] === ' ' || text[end] === '\t') {
+    end++
+  }
+
+  if (text.startsWith('\r\n', end)) {
+    return [range[0], end + 2]
+  }
+
+  if (text[end] === '\n') {
+    return [range[0], end + 1]
+  }
+
+  return [range[0], end]
 }
 
 function isTypeOnlyImport(node: ImportNode, spec: ImportSpecifierNode): boolean {

--- a/src/runtime/eslint/plugin.ts
+++ b/src/runtime/eslint/plugin.ts
@@ -1,0 +1,6 @@
+import { noRedundantImport } from './no-redundant-import'
+
+export default {
+  meta: { name: 'skill-hub' },
+  rules: { 'no-redundant-import': noRedundantImport },
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,11 @@ export interface ModuleOptions {
   targets?: SkillHubTarget[]
   moduleAuthoring?: boolean
   generationMode?: SkillHubGenerationMode
+  /**
+   * Auto-register ESLint rule to remove redundant imports when @nuxt/eslint is installed.
+   * @default true
+   */
+  eslint?: boolean
 }
 
 export interface AgentSkillDeclaration {

--- a/test/eslint-addon.test.ts
+++ b/test/eslint-addon.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { createAutoImportAddon } from '../src/eslint/addon'
+
+interface ImportEntry {
+  name: string
+  as?: string
+  from: string
+  type?: boolean
+}
+
+type HookCallback = (...args: unknown[]) => unknown
+
+function extractAutoImports(config: string): ImportEntry[] {
+  const match = config.match(/'skill-hub\/autoImports': (\[[^\n]+\])/)
+  if (!match) {
+    throw new Error('Failed to locate auto-import settings in generated ESLint config')
+  }
+  return JSON.parse(match[1]) as ImportEntry[]
+}
+
+describe('createAutoImportAddon', () => {
+  it('keeps type and value auto-import variants distinct', async () => {
+    const hooks = new Map<string, HookCallback>()
+    const nuxt = {
+      hook: (name: string, callback: HookCallback) => {
+        hooks.set(name, callback)
+      },
+    }
+
+    createAutoImportAddon(nuxt as never)
+
+    hooks.get('imports:context')?.({
+      getImports: async () => [
+        { name: 'Foo', from: 'pkg' },
+        { name: 'Foo', from: 'pkg', type: true },
+      ],
+    })
+
+    const addons: Array<{ getConfigs: () => Promise<{ configs?: string[] } | undefined> }> = []
+    hooks.get('eslint:config:addons')?.(addons)
+
+    expect(addons).toHaveLength(1)
+
+    const config = await addons[0].getConfigs()
+    const entries = extractAutoImports(config?.configs?.[0] || '')
+
+    expect(entries).toHaveLength(2)
+    expect(entries).toEqual(expect.arrayContaining([
+      { name: 'Foo', from: 'pkg' },
+      { name: 'Foo', from: 'pkg', type: true },
+    ]))
+  })
+})

--- a/test/eslint-no-redundant-import.test.ts
+++ b/test/eslint-no-redundant-import.test.ts
@@ -13,6 +13,7 @@ const settings = {
     { name: 'useFetch', from: '#app' },
     { name: 'useRoute', from: 'vue-router' },
     { name: 'navigateTo', from: '#app' },
+    { name: 'useAppConfig', as: 'useConfig', from: '#imports' },
   ],
 }
 
@@ -38,6 +39,8 @@ describe('no-redundant-import', () => {
         { code: `import { ref } from 'vue'`, settings: {} },
         // Mixed: only non-auto-imported specifiers
         { code: `import { createApp, defineComponent } from 'vue'`, settings },
+        // Type-only auto imports must not remove runtime imports
+        { code: `import { Foo } from 'pkg'`, settings: { 'skill-hub/autoImports': [{ name: 'Foo', from: 'pkg', type: true }] } },
       ],
       invalid: [
         // Single redundant → remove entire statement
@@ -88,6 +91,20 @@ describe('no-redundant-import', () => {
         {
           code: `import { ref, createApp, computed } from 'vue'`,
           output: `import { createApp } from 'vue'`,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // Aliased auto-imports should still be considered redundant
+        {
+          code: `import { useAppConfig as useConfig } from '#imports'\n`,
+          output: ``,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // Keep default imports intact when removing redundant named specifiers
+        {
+          code: `import Vue, { ref } from 'vue'`,
+          output: `import Vue from 'vue'`,
           errors: [{ messageId: 'redundant' }],
           settings,
         },

--- a/test/eslint-no-redundant-import.test.ts
+++ b/test/eslint-no-redundant-import.test.ts
@@ -41,6 +41,8 @@ describe('no-redundant-import', () => {
         { code: `import { createApp, defineComponent } from 'vue'`, settings },
         // Type-only auto imports must not remove runtime imports
         { code: `import { Foo } from 'pkg'`, settings: { 'skill-hub/autoImports': [{ name: 'Foo', from: 'pkg', type: true }] } },
+        // Local alias collision must not remove a different imported symbol
+        { code: `import { reactive as ref } from 'vue'`, settings },
       ],
       invalid: [
         // Single redundant → remove entire statement

--- a/test/eslint-no-redundant-import.test.ts
+++ b/test/eslint-no-redundant-import.test.ts
@@ -108,14 +108,23 @@ describe('no-redundant-import', () => {
           errors: [{ messageId: 'redundant' }],
           settings,
         },
+        // Full-removal fix must preserve same-line trailing code
+        {
+          code: `import { ref } from 'vue'; doWork()`,
+          output: `doWork()`,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
       ],
     })
   })
 
-  it('handles .d.ts files gracefully', () => {
+  it('handles declaration files gracefully', () => {
     tester.run('no-redundant-import', noRedundantImport, {
       valid: [
         { code: `import { ref } from 'vue'`, settings, filename: 'types.d.ts' },
+        { code: `import { ref } from 'vue'`, settings, filename: 'types.d.mts' },
+        { code: `import { ref } from 'vue'`, settings, filename: 'types.d.cts' },
       ],
       invalid: [],
     })

--- a/test/eslint-no-redundant-import.test.ts
+++ b/test/eslint-no-redundant-import.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from 'vitest'
+import { RuleTester } from 'eslint'
+import { noRedundantImport } from '../src/runtime/eslint/no-redundant-import'
+
+const settings = {
+  'skill-hub/autoImports': [
+    { name: 'ref', from: 'vue' },
+    { name: 'computed', from: 'vue' },
+    { name: 'watch', from: 'vue' },
+    { name: 'onMounted', from: 'vue' },
+    { name: 'Ref', from: 'vue', type: true },
+    { name: 'ComputedRef', from: 'vue', type: true },
+    { name: 'useFetch', from: '#app' },
+    { name: 'useRoute', from: 'vue-router' },
+    { name: 'navigateTo', from: '#app' },
+  ],
+}
+
+const tester = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: 'module' } })
+
+describe('no-redundant-import', () => {
+  it('reports and fixes redundant imports', () => {
+    tester.run('no-redundant-import', noRedundantImport, {
+      valid: [
+        // Not in auto-imports
+        { code: `import { createApp } from 'vue'`, settings },
+        // Different source
+        { code: `import { ref } from '@vue/reactivity'`, settings },
+        // Aliased — intentional rename
+        { code: `import { ref as myRef } from 'vue'`, settings },
+        // Default import
+        { code: `import Vue from 'vue'`, settings },
+        // Namespace import
+        { code: `import * as Vue from 'vue'`, settings },
+        // Side-effect import
+        { code: `import 'vue'`, settings },
+        // No settings — graceful no-op
+        { code: `import { ref } from 'vue'`, settings: {} },
+        // Mixed: only non-auto-imported specifiers
+        { code: `import { createApp, defineComponent } from 'vue'`, settings },
+      ],
+      invalid: [
+        // Single redundant → remove entire statement
+        {
+          code: `import { ref } from 'vue'\n`,
+          output: ``,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // All redundant → remove entire statement
+        {
+          code: `import { ref, computed, watch } from 'vue'\n`,
+          output: ``,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // Partial: ref is redundant, createApp is not
+        {
+          code: `import { ref, createApp } from 'vue'`,
+          output: `import { createApp } from 'vue'`,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // Partial: remove first specifier, keep second
+        {
+          code: `import { computed, createApp } from 'vue'`,
+          output: `import { createApp } from 'vue'`,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // Partial: remove last specifier, keep first
+        {
+          code: `import { createApp, ref } from 'vue'`,
+          output: `import { createApp } from 'vue'`,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // Mixed value + type: remove ref, keep type Ref (inline type specifier)
+        // Note: inline `type` specifiers need TS parser. For standard ESLint, test without.
+        // Nuxt composable from different source
+        {
+          code: `import { useRoute } from 'vue-router'\n`,
+          output: ``,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+        // Multiple redundant from different part of specifier list
+        {
+          code: `import { ref, createApp, computed } from 'vue'`,
+          output: `import { createApp } from 'vue'`,
+          errors: [{ messageId: 'redundant' }],
+          settings,
+        },
+      ],
+    })
+  })
+
+  it('handles .d.ts files gracefully', () => {
+    tester.run('no-redundant-import', noRedundantImport, {
+      valid: [
+        { code: `import { ref } from 'vue'`, settings, filename: 'types.d.ts' },
+      ],
+      invalid: [],
+    })
+  })
+})

--- a/test/module-setup.test.ts
+++ b/test/module-setup.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockEnsureStableSkillWrappers = vi.fn(async () => {})
 const mockGenerateSkillTree = vi.fn(async () => {})
+const mockCreateAutoImportAddon = vi.fn()
 const mockLogger = {
   info: vi.fn(),
   warn: vi.fn(),
@@ -27,6 +28,10 @@ vi.mock('std-env', () => ({
 vi.mock('../src/generator', () => ({
   ensureStableSkillWrappers: mockEnsureStableSkillWrappers,
   generateSkillTree: mockGenerateSkillTree,
+}))
+
+vi.mock('../src/eslint/addon', () => ({
+  createAutoImportAddon: mockCreateAutoImportAddon,
 }))
 
 vi.mock('../src/internal', () => ({
@@ -85,6 +90,42 @@ describe('module setup', () => {
     expect(mockGenerateSkillTree).toHaveBeenCalledWith(expect.objectContaining({
       generationMode: 'prepare',
     }))
+  })
+
+  it('registers the eslint addon by default and can opt out', async () => {
+    vi.resetModules()
+    const { default: importedModule } = await import('../src/module')
+    const moduleDefinition = importedModule as unknown as {
+      setup: (options: Record<string, unknown>, nuxt: unknown) => Promise<void>
+    }
+
+    const nuxt = {
+      options: {
+        rootDir: '/repo',
+        buildDir: '/repo/.nuxt',
+        _prepare: false,
+      },
+      hook: vi.fn(),
+    }
+
+    await moduleDefinition.setup({
+      skillName: 'nuxt-test',
+      generationMode: 'manual',
+      targets: ['claude'],
+    }, nuxt)
+
+    expect(mockCreateAutoImportAddon).toHaveBeenCalledWith(nuxt)
+
+    mockCreateAutoImportAddon.mockClear()
+
+    await moduleDefinition.setup({
+      skillName: 'nuxt-test',
+      generationMode: 'manual',
+      targets: ['claude'],
+      eslint: false,
+    }, nuxt)
+
+    expect(mockCreateAutoImportAddon).not.toHaveBeenCalled()
   })
 
   it('skips generation entirely during typecheck', async () => {

--- a/test/module-setup.test.ts
+++ b/test/module-setup.test.ts
@@ -119,7 +119,7 @@ describe('module setup', () => {
       expect(mockLogger.info).toHaveBeenCalledWith('Skipping skill generation during typecheck')
       expect(mockEnsureStableSkillWrappers).not.toHaveBeenCalled()
       expect(mockGenerateSkillTree).not.toHaveBeenCalled()
-      expect(prepareHooks.size).toBe(0)
+      expect(prepareHooks.has('prepare:types')).toBe(false)
     }
     finally {
       process.argv.length = 0


### PR DESCRIPTION
## Summary
- Ships an ESLint plugin (`nuxt-skill-hub/eslint-plugin`) with a `no-redundant-import` rule
- Auto-enabled when `@nuxt/eslint` is installed via the `eslint:config:addons` hook
- Collects auto-imports from Nuxt's `unimport` and passes them as ESLint settings
- Auto-fixes: removes redundant specifiers or entire statements, converts `import { type X }` to `import type { X }` when applicable

**Before**: `import { ref, computed } from 'vue'` (redundant — already auto-imported)
**After**: removed by `eslint --fix`

Opt-out: `skillHub: { eslint: false }` or `'skill-hub/no-redundant-import': 'off'`

## Test plan
- [x] ESLint rule unit tests with RuleTester (valid/invalid cases, partial removal, .d.ts skip)
- [x] Module setup test updated for new hook registration
- [x] Lint passes clean
- [x] Production build succeeds