### PR TITLE
[codex] resolve docs well-known skills

### DIFF
--- a/docs/server/utils/skill-discovery.ts
+++ b/docs/server/utils/skill-discovery.ts
@@ -1,5 +1,5 @@
 import { slugCandidates } from '../../../src/remote-resolver'
-import { GITHUB_OVERRIDES } from '../../../src/github-overrides'
+import { PACKAGE_OVERRIDES } from '../../../src/package-overrides'
 
 const COMMUNITY_REPO = 'onmax/nuxt-skills'
 const COMMUNITY_BRANCH = 'main'
@@ -66,12 +66,12 @@ export function resolveSkillFolder(nameOrPackage: string, skillFolders: Set<stri
 }
 
 /**
- * Fetch skills from official module repos (GITHUB_OVERRIDES).
+ * Fetch skills from official module repos (PACKAGE_OVERRIDES).
  * These take priority over community skills.
  */
 async function fetchOfficialSkills(): Promise<Record<string, ModuleSkillEntry>> {
   const results: Record<string, ModuleSkillEntry> = {}
-  const overridesWithRepo = GITHUB_OVERRIDES.filter(o => o.repo && o.path && o.skillName)
+  const overridesWithRepo = PACKAGE_OVERRIDES.filter(o => o.repo && o.path && o.skillName)
 
   await Promise.all(overridesWithRepo.map(async (override) => {
     try {

--- a/shared/skill-render.ts
+++ b/shared/skill-render.ts
@@ -1,7 +1,7 @@
 import { PACKAGE_VERSION } from './package-info'
 
 export type SkillSourceKind = 'dist' | 'github' | 'wellKnown' | 'generated'
-export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'wellKnownLegacy' | 'metadataRouter'
+export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'metadataRouter'
 export type SkillTrustLevel = 'official' | 'community'
 
 export interface NuxtPackMetadata {

--- a/shared/skill-render.ts
+++ b/shared/skill-render.ts
@@ -1,7 +1,7 @@
 import { PACKAGE_VERSION } from './package-info'
 
 export type SkillSourceKind = 'dist' | 'github' | 'wellKnown' | 'generated'
-export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'metadataRouter'
+export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'wellKnownV2' | 'metadataRouter'
 export type SkillTrustLevel = 'official' | 'community'
 
 export interface NuxtPackMetadata {

--- a/shared/skill-render.ts
+++ b/shared/skill-render.ts
@@ -1,7 +1,7 @@
 import { PACKAGE_VERSION } from './package-info'
 
-export type SkillSourceKind = 'dist' | 'github' | 'generated'
-export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'metadataRouter'
+export type SkillSourceKind = 'dist' | 'github' | 'wellKnown' | 'generated'
+export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'wellKnownLegacy' | 'metadataRouter'
 export type SkillTrustLevel = 'official' | 'community'
 
 export interface NuxtPackMetadata {
@@ -290,6 +290,8 @@ export function getSourceLabel(sourceKind: SkillSourceKind): string {
       return 'Installed package skill'
     case 'github':
       return 'Resolved module skill'
+    case 'wellKnown':
+      return 'Docs-discovered skill'
     case 'generated':
       return 'Metadata-routed skill'
   }
@@ -400,9 +402,10 @@ function relativeModuleLink(entry: SkillModuleRenderEntry, prefix: string): stri
 function groupModuleEntries(entries: SkillModuleRenderEntry[]) {
   const officialUpstream = entries.filter(entry => entry.sourceKind === 'dist')
   const githubResolved = entries.filter(entry => entry.sourceKind === 'github')
+  const wellKnownResolved = entries.filter(entry => entry.sourceKind === 'wellKnown')
   const metadataRouted = entries.filter(entry => entry.sourceKind === 'generated')
 
-  return { officialUpstream, githubResolved, metadataRouted }
+  return { officialUpstream, githubResolved, wellKnownResolved, metadataRouted }
 }
 
 function hasModuleGuidance(entries: SkillModuleRenderEntry[], skipped: SkillSkippedRenderEntry[] = []): boolean {
@@ -544,6 +547,7 @@ function createSkillMapSections(
   const moduleSections = [
     renderModuleGroup('Official upstream skills', grouped.officialUpstream, './references/modules/'),
     renderModuleGroup('Resolved module skills', grouped.githubResolved, './references/modules/'),
+    renderModuleGroup('Docs-discovered skills', grouped.wellKnownResolved, './references/modules/'),
     renderModuleGroup('Metadata-routed skills', grouped.metadataRouted, './references/modules/'),
     renderSkippedEntries(skipped),
   ].filter(Boolean)
@@ -661,6 +665,10 @@ function createResolverNote(entry: SkillModuleRenderEntry): string {
 
   if (entry.sourceKind === 'github') {
     return 'This module skill was resolved from GitHub heuristics. Verify important behavior against the installed module docs or source before relying on edge cases.'
+  }
+
+  if (entry.sourceKind === 'wellKnown') {
+    return 'This module skill was resolved from a docs .well-known endpoint. Treat it as product-published guidance, and verify version-sensitive details against the installed module docs or source.'
   }
 
   return 'This module router was generated from package metadata. Use the linked docs and repository as the source of truth for module-specific behavior.'

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -59,7 +59,7 @@ export interface GeneratedModuleEntry {
   docsUrl?: string
   official: boolean
   trustLevel: 'official' | 'community'
-  resolver: 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'metadataRouter'
+  resolver: 'agentsField' | 'githubHeuristic' | 'wellKnownV2' | 'metadataRouter'
   wrapperPath?: string
 }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -59,7 +59,7 @@ export interface GeneratedModuleEntry {
   docsUrl?: string
   official: boolean
   trustLevel: 'official' | 'community'
-  resolver: 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'wellKnownLegacy' | 'metadataRouter'
+  resolver: 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'metadataRouter'
   wrapperPath?: string
 }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -59,7 +59,7 @@ export interface GeneratedModuleEntry {
   docsUrl?: string
   official: boolean
   trustLevel: 'official' | 'community'
-  resolver: 'agentsField' | 'githubHeuristic' | 'metadataRouter'
+  resolver: 'agentsField' | 'githubHeuristic' | 'wellKnownRfc' | 'wellKnownLegacy' | 'metadataRouter'
   wrapperPath?: string
 }
 

--- a/src/package-overrides.ts
+++ b/src/package-overrides.ts
@@ -1,12 +1,13 @@
-export interface GitHubOverride {
+export interface PackageOverride {
   packageName: string
   repo?: string
   ref?: string
   path?: string
   skillName?: string
+  docsUrls?: string[]
 }
 
-export const GITHUB_OVERRIDES: GitHubOverride[] = [
+export const PACKAGE_OVERRIDES: PackageOverride[] = [
   {
     packageName: '@nuxt/ui',
     repo: 'nuxt/ui',
@@ -21,8 +22,13 @@ export const GITHUB_OVERRIDES: GitHubOverride[] = [
     path: 'skills/vueuse-functions',
     skillName: 'vueuse-functions',
   },
+  {
+    packageName: 'docus',
+    repo: 'nuxt-content/docus',
+    docsUrls: ['https://docus.dev/'],
+  },
 ]
 
-export function findGitHubOverride(packageName: string): GitHubOverride | undefined {
-  return GITHUB_OVERRIDES.find(entry => entry.packageName === packageName)
+export function findPackageOverride(packageName: string): PackageOverride | undefined {
+  return PACKAGE_OVERRIDES.find(entry => entry.packageName === packageName)
 }

--- a/src/remote-fetch.ts
+++ b/src/remote-fetch.ts
@@ -11,6 +11,8 @@ interface GitHubTreeEntry {
 const githubDirectoryCache = new Map<string, Promise<string[]>>()
 const githubDefaultBranchCache = new Map<string, Promise<string | null>>()
 const githubFileTextCache = new Map<string, Promise<{ ok: boolean, data?: string, status?: number, error?: string }>>()
+const urlTextCache = new Map<string, Promise<{ ok: boolean, data?: string, status?: number, error?: string }>>()
+const urlBytesCache = new Map<string, Promise<{ ok: boolean, data?: Uint8Array, status?: number, error?: string }>>()
 
 function githubFetchOptions(timeoutMs: number) {
   return {
@@ -20,6 +22,12 @@ function githubFetchOptions(timeoutMs: number) {
       'User-Agent': 'nuxt-skill-hub',
     },
   }
+}
+
+function fetchStatus(error: unknown): number | undefined {
+  return typeof error === 'object' && error && 'status' in error
+    ? Number((error as { status?: number }).status)
+    : undefined
 }
 
 function encodeGitHubPath(path: string): string {
@@ -169,13 +177,74 @@ export async function fetchGitHubFileText(
       return { ok: true, data }
     }
     catch (error) {
-      const status = typeof error === 'object' && error && 'status' in error
-        ? Number((error as { status?: number }).status)
-        : undefined
-
       return {
         ok: false,
-        status,
+        status: fetchStatus(error),
+        error: (error as Error).message,
+      }
+    }
+  })
+}
+
+export async function fetchUrlText(url: string, timeoutMs: number): Promise<{ ok: boolean, data?: string, status?: number, error?: string }> {
+  return await memoize(urlTextCache, url, async () => {
+    try {
+      const data = await ofetch(url, {
+        ...githubFetchOptions(timeoutMs),
+        responseType: 'text' as const,
+      })
+      return { ok: true, data }
+    }
+    catch (error) {
+      return {
+        ok: false,
+        status: fetchStatus(error),
+        error: (error as Error).message,
+      }
+    }
+  })
+}
+
+export async function fetchUrlJson<T>(url: string, timeoutMs: number): Promise<{ ok: boolean, data?: T, status?: number, error?: string }> {
+  const text = await fetchUrlText(url, timeoutMs)
+  if (!text.ok) {
+    return {
+      ok: false,
+      status: text.status,
+      error: text.error,
+    }
+  }
+
+  try {
+    return {
+      ok: true,
+      data: JSON.parse(text.data || '') as T,
+    }
+  }
+  catch (error) {
+    return {
+      ok: false,
+      error: (error as Error).message,
+    }
+  }
+}
+
+export async function fetchUrlBytes(url: string, timeoutMs: number): Promise<{ ok: boolean, data?: Uint8Array, status?: number, error?: string }> {
+  return await memoize(urlBytesCache, url, async () => {
+    try {
+      const data = await ofetch<ArrayBuffer, 'arrayBuffer'>(url, {
+        ...githubFetchOptions(timeoutMs),
+        responseType: 'arrayBuffer' as const,
+      })
+      return {
+        ok: true,
+        data: new Uint8Array(data),
+      }
+    }
+    catch (error) {
+      return {
+        ok: false,
+        status: fetchStatus(error),
         error: (error as Error).message,
       }
     }

--- a/src/remote-resolver.ts
+++ b/src/remote-resolver.ts
@@ -1,8 +1,9 @@
 import { promises as fsp } from 'node:fs'
 import { downloadTemplate } from 'giget'
 import { dirname, join } from 'pathe'
-import { findGitHubOverride } from './github-overrides'
+import { findPackageOverride } from './package-overrides'
 import { fetchGitHubDefaultBranch, fetchGitHubFileText, listGitHubDirectory, parseGitHubRepo } from './remote-fetch'
+import { resolveViaWellKnown } from './well-known-resolver'
 import { createMetadataRouterSkillFiles, resolveMetadataRouterSkillName } from './render-content'
 import type { ResolvedContribution, SkillManifestSkipped, SkillSourceKind, ValidationIssue } from './types'
 import { createValidationIssue, ensureDir, normalizeContribution, parseAgentSkillDeclarations, pathExists, sanitizeSegment } from './internal'
@@ -91,8 +92,15 @@ function normalizeHttpUrl(url: string | undefined): string | undefined {
   }
 }
 
+function resolveDocsUrl(packageInfo: InstalledPackageInfo): string | undefined {
+  const override = findPackageOverride(packageInfo.packageName)
+  const overrideDocsUrl = override?.docsUrls?.map(normalizeHttpUrl).find(Boolean)
+  return overrideDocsUrl || normalizeHttpUrl(packageInfo.homepage)
+}
+
 function resolveRepositoryUrl(packageInfo: InstalledPackageInfo): { repoUrl?: string, sourceRepo?: string } {
-  const sourceRepo = parseGitHubRepo(packageInfo.repository) || parseGitHubRepo(packageInfo.homepage)
+  const override = findPackageOverride(packageInfo.packageName)
+  const sourceRepo = override?.repo || parseGitHubRepo(packageInfo.repository) || parseGitHubRepo(packageInfo.homepage)
   if (sourceRepo) {
     return {
       sourceRepo,
@@ -181,25 +189,20 @@ async function materializeCandidate(
   }, targetDir, join(targetDir, '..'))
 }
 
-async function resolveViaGitHub(
-  packageInfo: InstalledPackageInfo,
-  cacheRoot: string,
-  timeoutMs: number,
-): Promise<RemoteResolveResult> {
-  const issues: ValidationIssue[] = []
-  const skipped: SkillManifestSkipped[] = []
-  const override = findGitHubOverride(packageInfo.packageName)
+interface GitHubResolveContext {
+  issues: ValidationIssue[]
+  skipped: SkillManifestSkipped[]
+  override: ReturnType<typeof findPackageOverride>
+  repo?: string
+  refs: string[]
+  pathCandidates: string[]
+}
+
+function createGitHubResolveContext(packageInfo: InstalledPackageInfo): GitHubResolveContext {
+  const override = findPackageOverride(packageInfo.packageName)
   const repo = override?.repo
     || parseGitHubRepo(packageInfo.repository)
     || parseGitHubRepo(packageInfo.homepage)
-
-  if (!repo) {
-    return {
-      contributions: [],
-      issues,
-      skipped: [makeSkip(packageInfo.packageName, override?.skillName || packageInfo.packageName, 'No GitHub repository metadata found', 'github')],
-    }
-  }
 
   const refs = dedupe([
     override?.ref || '',
@@ -222,20 +225,45 @@ async function resolveViaGitHub(
     }),
   ])
 
-  const tryResolveForRef = async (ref: string, allowTreeLookup: boolean): Promise<ResolvedContribution[] | null> => {
-    const packageJson = await fetchGitHubFileText(repo, ref, 'package.json', timeoutMs)
+  return {
+    issues: [],
+    skipped: [],
+    override,
+    repo: repo || undefined,
+    refs,
+    pathCandidates,
+  }
+}
+
+async function resolveViaGitHubAgents(
+  packageInfo: InstalledPackageInfo,
+  cacheRoot: string,
+  timeoutMs: number,
+): Promise<RemoteResolveResult> {
+  const context = createGitHubResolveContext(packageInfo)
+
+  if (!context.repo) {
+    return {
+      contributions: [],
+      issues: context.issues,
+      skipped: [],
+    }
+  }
+
+  const tryResolveForRef = async (ref: string): Promise<ResolvedContribution[] | null> => {
+    const packageJson = await fetchGitHubFileText(context.repo!, ref, 'package.json', timeoutMs)
     if (packageJson.ok && packageJson.data) {
       try {
         const parsed = JSON.parse(packageJson.data) as unknown
         const remoteSkills = parseAgentSkillDeclarations(parsed, packageInfo.packageName, 'github')
-        issues.push(...remoteSkills.issues)
+        context.issues.push(...remoteSkills.issues)
 
         for (const skill of remoteSkills.skills) {
           const resolved = await materializeCandidate(packageInfo, {
             skillName: skill.name,
             sourcePath: skill.path,
             sourceKind: 'github',
-            sourceRepo: repo,
+            sourceRepo: context.repo!,
             sourceRef: ref,
             official: true,
             resolver: 'agentsField',
@@ -246,15 +274,58 @@ async function resolveViaGitHub(
         }
       }
       catch {
-        issues.push(createValidationIssue(packageInfo.packageName, packageInfo.packageName, 'Failed to parse remote package.json', 'github'))
+        context.issues.push(createValidationIssue(packageInfo.packageName, packageInfo.packageName, 'Failed to parse remote package.json', 'github'))
       }
     }
 
-    if (!allowTreeLookup) {
-      return null
+    return null
+  }
+
+  for (const ref of context.refs) {
+    const resolved = await tryResolveForRef(ref)
+    if (resolved?.length) {
+      return { contributions: resolved, issues: context.issues, skipped: context.skipped }
+    }
+  }
+
+  return {
+    contributions: [],
+    issues: context.issues,
+    skipped: context.skipped,
+  }
+}
+
+async function resolveViaGitHubHeuristics(
+  packageInfo: InstalledPackageInfo,
+  cacheRoot: string,
+  timeoutMs: number,
+): Promise<RemoteResolveResult> {
+  const context = createGitHubResolveContext(packageInfo)
+
+  if (!context.repo) {
+    return {
+      contributions: [],
+      issues: context.issues,
+      skipped: [makeSkip(packageInfo.packageName, context.override?.skillName || packageInfo.packageName, 'No GitHub repository metadata found', 'github')],
+    }
+  }
+
+  const tryResolveForRef = async (ref: string, allowTreeLookup: boolean): Promise<ResolvedContribution[] | null> => {
+    if (allowTreeLookup) {
+      const packageJson = await fetchGitHubFileText(context.repo!, ref, 'package.json', timeoutMs)
+      if (packageJson.ok && packageJson.data) {
+        try {
+          const parsed = JSON.parse(packageJson.data) as unknown
+          const remoteSkills = parseAgentSkillDeclarations(parsed, packageInfo.packageName, 'github')
+          context.issues.push(...remoteSkills.issues)
+        }
+        catch {
+          context.issues.push(createValidationIssue(packageInfo.packageName, packageInfo.packageName, 'Failed to parse remote package.json', 'github'))
+        }
+      }
     }
 
-    const skillsDirs = await listGitHubDirectory(repo, ref, 'skills', timeoutMs)
+    const skillsDirs = allowTreeLookup ? await listGitHubDirectory(context.repo!, ref, 'skills', timeoutMs) : []
     if (skillsDirs.length) {
       const contributions: ResolvedContribution[] = []
       for (const skillName of skillsDirs) {
@@ -262,7 +333,7 @@ async function resolveViaGitHub(
           skillName,
           sourcePath: `skills/${skillName}`,
           sourceKind: 'github',
-          sourceRepo: repo,
+          sourceRepo: context.repo!,
           sourceRef: ref,
           official: true,
           resolver: 'githubHeuristic',
@@ -276,16 +347,16 @@ async function resolveViaGitHub(
       }
     }
 
-    for (const path of pathCandidates) {
-      const candidateSkillName = override?.path && path === override.path
-        ? (override.skillName || path.split('/').pop() || packageInfo.packageName)
+    for (const path of context.pathCandidates) {
+      const candidateSkillName = context.override?.path && path === context.override.path
+        ? (context.override.skillName || path.split('/').pop() || packageInfo.packageName)
         : path.split('/').pop() || packageInfo.packageName
 
       const resolved = await materializeCandidate(packageInfo, {
         skillName: candidateSkillName,
         sourcePath: path,
         sourceKind: 'github',
-        sourceRepo: repo,
+        sourceRepo: context.repo!,
         sourceRef: ref,
         official: true,
         resolver: 'githubHeuristic',
@@ -299,15 +370,8 @@ async function resolveViaGitHub(
     return null
   }
 
-  for (const ref of refs) {
-    const resolved = await tryResolveForRef(ref, false)
-    if (resolved?.length) {
-      return { contributions: resolved, issues, skipped }
-    }
-  }
-
   const fallbackRefs = dedupe([
-    await fetchGitHubDefaultBranch(repo, timeoutMs) || '',
+    await fetchGitHubDefaultBranch(context.repo, timeoutMs) || '',
     'main',
     'master',
   ])
@@ -315,22 +379,22 @@ async function resolveViaGitHub(
   for (const ref of fallbackRefs) {
     const resolved = await tryResolveForRef(ref, true)
     if (resolved?.length) {
-      return { contributions: resolved, issues, skipped }
+      return { contributions: resolved, issues: context.issues, skipped: context.skipped }
     }
   }
 
-  for (const ref of refs) {
+  for (const ref of context.refs) {
     const resolved = await tryResolveForRef(ref, true)
     if (resolved?.length) {
-      return { contributions: resolved, issues, skipped }
+      return { contributions: resolved, issues: context.issues, skipped: context.skipped }
     }
   }
 
-  skipped.push(makeSkip(packageInfo.packageName, override?.skillName || packageInfo.packageName, 'No GitHub skill found using configured refs and path heuristics', 'github'))
+  context.skipped.push(makeSkip(packageInfo.packageName, context.override?.skillName || packageInfo.packageName, 'No GitHub skill found using configured refs and path heuristics', 'github'))
   return {
     contributions: [],
-    issues,
-    skipped,
+    issues: context.issues,
+    skipped: context.skipped,
   }
 }
 
@@ -339,7 +403,7 @@ async function resolveViaMetadataRouter(
   cacheRoot: string,
 ): Promise<RemoteResolveResult> {
   const { repoUrl, sourceRepo } = resolveRepositoryUrl(packageInfo)
-  const docsUrl = normalizeHttpUrl(packageInfo.homepage)
+  const docsUrl = resolveDocsUrl(packageInfo)
 
   if (!repoUrl && !docsUrl) {
     return {
@@ -423,16 +487,42 @@ export async function resolveRemoteContributionsForPackage(
   packageInfo: InstalledPackageInfo,
   options: RemoteResolveOptions,
 ): Promise<RemoteResolveResult> {
-  const githubResult = options.enableGithubLookup
-    ? await resolveViaGitHub(packageInfo, options.cacheRoot, options.githubLookupTimeoutMs)
+  const githubAgentsResult = options.enableGithubLookup
+    ? await resolveViaGitHubAgents(packageInfo, options.cacheRoot, options.githubLookupTimeoutMs)
     : {
         contributions: [],
         issues: [],
         skipped: [],
       }
 
-  if (githubResult.contributions.length) {
-    return githubResult
+  if (githubAgentsResult.contributions.length) {
+    return githubAgentsResult
+  }
+
+  const wellKnownResult = await resolveViaWellKnown(packageInfo, options.cacheRoot, options.githubLookupTimeoutMs)
+
+  if (wellKnownResult.contributions.length) {
+    return {
+      contributions: wellKnownResult.contributions,
+      issues: [...githubAgentsResult.issues, ...wellKnownResult.issues],
+      skipped: wellKnownResult.skipped,
+    }
+  }
+
+  const githubHeuristicResult = options.enableGithubLookup
+    ? await resolveViaGitHubHeuristics(packageInfo, options.cacheRoot, options.githubLookupTimeoutMs)
+    : {
+        contributions: [],
+        issues: [],
+        skipped: [],
+      }
+
+  if (githubHeuristicResult.contributions.length) {
+    return {
+      contributions: githubHeuristicResult.contributions,
+      issues: [...githubAgentsResult.issues, ...wellKnownResult.issues, ...githubHeuristicResult.issues],
+      skipped: wellKnownResult.skipped,
+    }
   }
 
   const generatedResult = await resolveViaMetadataRouter(packageInfo, options.cacheRoot)
@@ -440,14 +530,14 @@ export async function resolveRemoteContributionsForPackage(
   if (generatedResult.contributions.length) {
     return {
       contributions: generatedResult.contributions,
-      issues: [...githubResult.issues, ...generatedResult.issues],
-      skipped: generatedResult.skipped,
+      issues: [...githubAgentsResult.issues, ...wellKnownResult.issues, ...githubHeuristicResult.issues, ...generatedResult.issues],
+      skipped: [...wellKnownResult.skipped, ...generatedResult.skipped],
     }
   }
 
   return {
     contributions: [],
-    issues: [...githubResult.issues, ...generatedResult.issues],
-    skipped: [...githubResult.skipped, ...generatedResult.skipped],
+    issues: [...githubAgentsResult.issues, ...wellKnownResult.issues, ...githubHeuristicResult.issues, ...generatedResult.issues],
+    skipped: [...wellKnownResult.skipped, ...githubHeuristicResult.skipped, ...generatedResult.skipped],
   }
 }

--- a/src/remote-resolver.ts
+++ b/src/remote-resolver.ts
@@ -235,6 +235,49 @@ function createGitHubResolveContext(packageInfo: InstalledPackageInfo): GitHubRe
   }
 }
 
+async function resolveAgentSkillsForRef(
+  packageInfo: InstalledPackageInfo,
+  context: GitHubResolveContext,
+  ref: string,
+  cacheRoot: string,
+  timeoutMs: number,
+): Promise<ResolvedContribution[] | null> {
+  if (!context.repo) {
+    return null
+  }
+
+  const packageJson = await fetchGitHubFileText(context.repo, ref, 'package.json', timeoutMs)
+  if (!packageJson.ok || !packageJson.data) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(packageJson.data) as unknown
+    const remoteSkills = parseAgentSkillDeclarations(parsed, packageInfo.packageName, 'github')
+    context.issues.push(...remoteSkills.issues)
+
+    for (const skill of remoteSkills.skills) {
+      const resolved = await materializeCandidate(packageInfo, {
+        skillName: skill.name,
+        sourcePath: skill.path,
+        sourceKind: 'github',
+        sourceRepo: context.repo,
+        sourceRef: ref,
+        official: true,
+        resolver: 'agentsField',
+      }, cacheRoot)
+      if (resolved) {
+        return [resolved]
+      }
+    }
+  }
+  catch {
+    context.issues.push(createValidationIssue(packageInfo.packageName, packageInfo.packageName, 'Failed to parse remote package.json', 'github'))
+  }
+
+  return null
+}
+
 async function resolveViaGitHubAgents(
   packageInfo: InstalledPackageInfo,
   cacheRoot: string,
@@ -250,39 +293,21 @@ async function resolveViaGitHubAgents(
     }
   }
 
-  const tryResolveForRef = async (ref: string): Promise<ResolvedContribution[] | null> => {
-    const packageJson = await fetchGitHubFileText(context.repo!, ref, 'package.json', timeoutMs)
-    if (packageJson.ok && packageJson.data) {
-      try {
-        const parsed = JSON.parse(packageJson.data) as unknown
-        const remoteSkills = parseAgentSkillDeclarations(parsed, packageInfo.packageName, 'github')
-        context.issues.push(...remoteSkills.issues)
-
-        for (const skill of remoteSkills.skills) {
-          const resolved = await materializeCandidate(packageInfo, {
-            skillName: skill.name,
-            sourcePath: skill.path,
-            sourceKind: 'github',
-            sourceRepo: context.repo!,
-            sourceRef: ref,
-            official: true,
-            resolver: 'agentsField',
-          }, cacheRoot)
-          if (resolved) {
-            return [resolved]
-          }
-        }
-      }
-      catch {
-        context.issues.push(createValidationIssue(packageInfo.packageName, packageInfo.packageName, 'Failed to parse remote package.json', 'github'))
-      }
+  for (const ref of context.refs) {
+    const resolved = await resolveAgentSkillsForRef(packageInfo, context, ref, cacheRoot, timeoutMs)
+    if (resolved?.length) {
+      return { contributions: resolved, issues: context.issues, skipped: context.skipped }
     }
-
-    return null
   }
 
-  for (const ref of context.refs) {
-    const resolved = await tryResolveForRef(ref)
+  const fallbackRefs = dedupe([
+    await fetchGitHubDefaultBranch(context.repo, timeoutMs) || '',
+    'main',
+    'master',
+  ])
+
+  for (const ref of fallbackRefs) {
+    const resolved = await resolveAgentSkillsForRef(packageInfo, context, ref, cacheRoot, timeoutMs)
     if (resolved?.length) {
       return { contributions: resolved, issues: context.issues, skipped: context.skipped }
     }
@@ -311,20 +336,6 @@ async function resolveViaGitHubHeuristics(
   }
 
   const tryResolveForRef = async (ref: string, allowTreeLookup: boolean): Promise<ResolvedContribution[] | null> => {
-    if (allowTreeLookup) {
-      const packageJson = await fetchGitHubFileText(context.repo!, ref, 'package.json', timeoutMs)
-      if (packageJson.ok && packageJson.data) {
-        try {
-          const parsed = JSON.parse(packageJson.data) as unknown
-          const remoteSkills = parseAgentSkillDeclarations(parsed, packageInfo.packageName, 'github')
-          context.issues.push(...remoteSkills.issues)
-        }
-        catch {
-          context.issues.push(createValidationIssue(packageInfo.packageName, packageInfo.packageName, 'Failed to parse remote package.json', 'github'))
-        }
-      }
-    }
-
     const skillsDirs = allowTreeLookup ? await listGitHubDirectory(context.repo!, ref, 'skills', timeoutMs) : []
     if (skillsDirs.length) {
       const contributions: ResolvedContribution[] = []

--- a/src/well-known-resolver.ts
+++ b/src/well-known-resolver.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { promises as fsp } from 'node:fs'
+import { isIP } from 'node:net'
 import { dirname, join } from 'pathe'
 import { findPackageOverride } from './package-overrides'
 import { fetchUrlBytes, fetchUrlJson, parseGitHubRepo } from './remote-fetch'
@@ -64,13 +65,116 @@ function normalizeHttpUrl(url: string | undefined): string | undefined {
   }
 }
 
-function isDocsDiscoveryBase(url: string): boolean {
-  const parsed = new URL(url)
-  if (parsed.hostname === 'github.com' || parseGitHubRepo(url)) {
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '')
+}
+
+function parseIpv4(hostname: string): [number, number, number, number] | null {
+  const parts = hostname.split('.')
+  if (parts.length !== 4) {
+    return null
+  }
+
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) {
+      return Number.NaN
+    }
+
+    return Number(part)
+  })
+
+  if (octets.some(octet => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return null
+  }
+
+  return octets as [number, number, number, number]
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = parseIpv4(normalizeHostname(hostname))
+  if (!octets) {
     return false
   }
 
-  return true
+  const [a, b] = octets
+  return a === 0
+    || a === 10
+    || a === 127
+    || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && b === 168)
+    || (a >= 224 && a <= 239)
+    || a >= 240
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname)
+  return normalized === '::'
+    || normalized === '::1'
+    || normalized.startsWith('fc')
+    || normalized.startsWith('fd')
+    || normalized.startsWith('fe8')
+    || normalized.startsWith('fe9')
+    || normalized.startsWith('fea')
+    || normalized.startsWith('feb')
+}
+
+function isUnsafeHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname)
+
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) {
+    return true
+  }
+
+  const ipVersion = isIP(normalized)
+  if (ipVersion === 4) {
+    return isPrivateIpv4(normalized)
+  }
+  if (ipVersion === 6) {
+    return isPrivateIpv6(normalized)
+  }
+
+  return false
+}
+
+function isPublicDiscoveryBase(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+      || parsed.hostname === 'github.com'
+      || parseGitHubRepo(url)
+      || isUnsafeHostname(parsed.hostname)) {
+      return false
+    }
+
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+function isSameOriginUrl(url: string, baseUrl: string): boolean {
+  return new URL(url).origin === new URL(baseUrl).origin
+}
+
+function resolveSameOriginUrl(rawUrl: string, baseUrl: string): string | null {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const resolved = new URL(trimmed, baseUrl)
+    if (!isSameOriginUrl(resolved.toString(), baseUrl) || isUnsafeHostname(resolved.hostname)) {
+      return null
+    }
+
+    return resolved.toString()
+  }
+  catch {
+    return null
+  }
 }
 
 function docsBaseCandidates(packageInfo: InstalledPackageInfo): string[] {
@@ -83,7 +187,7 @@ function docsBaseCandidates(packageInfo: InstalledPackageInfo): string[] {
   return [...new Set(candidates
     .map(normalizeHttpUrl)
     .filter((url): url is string => Boolean(url))
-    .filter(isDocsDiscoveryBase))]
+    .filter(isPublicDiscoveryBase))]
 }
 
 function isSafeRelativeFilePath(path: string): boolean {
@@ -293,7 +397,11 @@ async function materializeRfcSkill(input: {
     return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill is missing a valid sha256 digest') }
   }
 
-  const skillUrl = new URL(input.entry.url, input.indexUrl).toString()
+  const skillUrl = resolveSameOriginUrl(input.entry.url, input.indexUrl)
+  if (!skillUrl) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill URL must stay on the discovery origin') }
+  }
+
   const response = await fetchUrlBytes(skillUrl, input.timeoutMs)
   if (!response.ok || !response.data) {
     return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'failed to fetch RFC well-known skill artifact') }

--- a/src/well-known-resolver.ts
+++ b/src/well-known-resolver.ts
@@ -8,9 +8,10 @@ import { emptyDir, ensureDir, isValidSkillName, normalizeContribution, sanitizeS
 import type { InstalledPackageInfo, RemoteResolveResult } from './remote-resolver'
 import type { ResolvedContribution, SkillManifestSkipped, ValidationIssue } from './types'
 
-const RFC_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
+const WELL_KNOWN_DISCOVERY_V2_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
+const WELL_KNOWN_DISCOVERY_V2_INDEX_PATH = '/.well-known/agent-skills/index.json'
 
-interface RfcSkillEntry {
+interface WellKnownV2SkillEntry {
   name?: unknown
   type?: unknown
   description?: unknown
@@ -18,7 +19,7 @@ interface RfcSkillEntry {
   digest?: unknown
 }
 
-interface RfcIndex {
+interface WellKnownV2Index {
   $schema?: unknown
   skills?: unknown
 }
@@ -204,7 +205,7 @@ function contributionFor(input: {
   skillName: string
   description?: string
   docsUrl: string
-  resolver: 'wellKnownRfc'
+  resolver: 'wellKnownV2'
   indexUrl: string
 }): ResolvedContribution {
   const sourceRepo = parseGitHubRepo(input.packageInfo.repository)
@@ -226,9 +227,9 @@ function contributionFor(input: {
   }, input.targetDir, join(input.targetDir, '..'))
 }
 
-async function materializeRfcSkill(input: {
+async function materializeV2Skill(input: {
   packageInfo: InstalledPackageInfo
-  entry: RfcSkillEntry
+  entry: WellKnownV2SkillEntry
   indexUrl: string
   docsUrl: string
   cacheRoot: string
@@ -236,12 +237,12 @@ async function materializeRfcSkill(input: {
 }): Promise<MaterializedSkill | null> {
   const skillName = typeof input.entry.name === 'string' ? input.entry.name.trim() : ''
   if (!isValidSkillName(skillName)) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName || 'entry', 'RFC well-known skill name is invalid') }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName || 'entry', 'well-known v2 skill name is invalid') }
   }
 
   const description = typeof input.entry.description === 'string' ? input.entry.description.trim() : ''
   if (!description) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill is missing a description') }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known v2 skill is missing a description') }
   }
 
   const type = typeof input.entry.type === 'string' ? input.entry.type.trim() : ''
@@ -249,30 +250,30 @@ async function materializeRfcSkill(input: {
     return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'archive artifacts are not supported yet') }
   }
   if (type !== 'skill-md') {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, `unsupported RFC well-known skill type "${type || 'unknown'}"`) }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, `unsupported well-known v2 skill type "${type || 'unknown'}"`) }
   }
 
   if (typeof input.entry.url !== 'string' || !input.entry.url.trim()) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill is missing a URL') }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known v2 skill is missing a URL') }
   }
 
   const digest = normalizeDigest(input.entry.digest)
   if (!digest) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill is missing a valid sha256 digest') }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known v2 skill is missing a valid sha256 digest') }
   }
 
   const skillUrl = resolveSameOriginUrl(input.entry.url, input.indexUrl)
   if (!skillUrl) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill URL must stay on the discovery origin') }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known v2 skill URL must stay on the discovery origin') }
   }
 
   const response = await fetchUrlBytes(skillUrl, input.timeoutMs)
   if (!response.ok || !response.data) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'failed to fetch RFC well-known skill artifact') }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'failed to fetch well-known v2 skill artifact') }
   }
 
   if (sha256(response.data) !== digest) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill digest mismatch') }
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known v2 skill digest mismatch') }
   }
 
   const origin = new URL(input.docsUrl).origin
@@ -296,15 +297,15 @@ async function materializeRfcSkill(input: {
       skillName,
       description,
       docsUrl: input.docsUrl,
-      resolver: 'wellKnownRfc',
+      resolver: 'wellKnownV2',
       indexUrl: input.indexUrl,
     }),
   }
 }
 
-async function resolveRfcIndex(input: {
+async function resolveV2Index(input: {
   packageInfo: InstalledPackageInfo
-  index: RfcIndex
+  index: WellKnownV2Index
   indexUrl: string
   docsUrl: string
   cacheRoot: string
@@ -317,19 +318,19 @@ async function resolveRfcIndex(input: {
     return {
       contributions: [],
       issues: [],
-      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'RFC well-known index is missing a skills array')],
+      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'well-known v2 index is missing a skills array')],
     }
   }
 
   for (const rawEntry of input.index.skills) {
     if (!rawEntry || typeof rawEntry !== 'object') {
-      skipped.push(makeSkip(input.packageInfo.packageName, 'entry', 'RFC well-known skill entry must be an object'))
+      skipped.push(makeSkip(input.packageInfo.packageName, 'entry', 'well-known v2 skill entry must be an object'))
       continue
     }
 
-    const materialized = await materializeRfcSkill({
+    const materialized = await materializeV2Skill({
       packageInfo: input.packageInfo,
-      entry: rawEntry as RfcSkillEntry,
+      entry: rawEntry as WellKnownV2SkillEntry,
       indexUrl: input.indexUrl,
       docsUrl: input.docsUrl,
       cacheRoot: input.cacheRoot,
@@ -354,7 +355,7 @@ async function resolveIndex(input: {
   cacheRoot: string
   timeoutMs: number
 }): Promise<RemoteResolveResult | null> {
-  const response = await fetchUrlJson<RfcIndex>(input.indexUrl, input.timeoutMs)
+  const response = await fetchUrlJson<WellKnownV2Index>(input.indexUrl, input.timeoutMs)
   if (!response.ok) {
     if (response.status === 404) {
       return null
@@ -376,8 +377,8 @@ async function resolveIndex(input: {
     }
   }
 
-  if (index.$schema === RFC_SCHEMA) {
-    return await resolveRfcIndex({
+  if (index.$schema === WELL_KNOWN_DISCOVERY_V2_SCHEMA) {
+    return await resolveV2Index({
       ...input,
       index,
     })
@@ -394,7 +395,7 @@ async function resolveIndex(input: {
   return {
     contributions: [],
     issues: [],
-    skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'well-known index is missing a supported schema')],
+    skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'well-known index is missing the v2 schema')],
   }
 }
 
@@ -408,7 +409,7 @@ export async function resolveViaWellKnown(
   const issues: ValidationIssue[] = []
 
   for (const docsUrl of bases) {
-    const indexUrl = new URL('/.well-known/agent-skills/index.json', docsUrl).toString()
+    const indexUrl = new URL(WELL_KNOWN_DISCOVERY_V2_INDEX_PATH, docsUrl).toString()
     const result = await resolveIndex({
       packageInfo,
       indexUrl,

--- a/src/well-known-resolver.ts
+++ b/src/well-known-resolver.ts
@@ -10,17 +10,6 @@ import type { ResolvedContribution, SkillManifestSkipped, ValidationIssue } from
 
 const RFC_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
 
-interface LegacySkillEntry {
-  name?: unknown
-  description?: unknown
-  files?: unknown
-}
-
-interface LegacyIndex {
-  $schema?: unknown
-  skills?: unknown
-}
-
 interface RfcSkillEntry {
   name?: unknown
   type?: unknown
@@ -190,19 +179,6 @@ function docsBaseCandidates(packageInfo: InstalledPackageInfo): string[] {
     .filter(isPublicDiscoveryBase))]
 }
 
-function isSafeRelativeFilePath(path: string): boolean {
-  if (!path || path.includes('\0') || path.includes('\\') || path.startsWith('/')) {
-    return false
-  }
-
-  const parts = path.split('/')
-  return parts.every(part => part && part !== '.' && part !== '..')
-}
-
-function encodeRelativePath(path: string): string {
-  return path.split('/').map(part => encodeURIComponent(part)).join('/')
-}
-
 function normalizeDigest(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null
@@ -228,7 +204,7 @@ function contributionFor(input: {
   skillName: string
   description?: string
   docsUrl: string
-  resolver: 'wellKnownRfc' | 'wellKnownLegacy'
+  resolver: 'wellKnownRfc'
   indexUrl: string
 }): ResolvedContribution {
   const sourceRepo = parseGitHubRepo(input.packageInfo.repository)
@@ -248,118 +224,6 @@ function contributionFor(input: {
     resolver: input.resolver,
     forceIncludeScripts: true,
   }, input.targetDir, join(input.targetDir, '..'))
-}
-
-async function materializeLegacySkill(input: {
-  packageInfo: InstalledPackageInfo
-  entry: LegacySkillEntry
-  indexUrl: string
-  docsUrl: string
-  cacheRoot: string
-  timeoutMs: number
-}): Promise<MaterializedSkill | null> {
-  const skillName = typeof input.entry.name === 'string' ? input.entry.name.trim() : ''
-  if (!isValidSkillName(skillName)) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName || 'entry', 'legacy well-known skill name is invalid') }
-  }
-
-  const description = typeof input.entry.description === 'string' ? input.entry.description.trim() : ''
-  if (!description) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'legacy well-known skill is missing a description') }
-  }
-
-  if (!Array.isArray(input.entry.files) || !input.entry.files.every(file => typeof file === 'string')) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'legacy well-known skill files must be a string array') }
-  }
-
-  const files = input.entry.files.map(file => file.trim())
-  if (!files.includes('SKILL.md')) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'legacy well-known skill must include SKILL.md') }
-  }
-
-  const unsafePath = files.find(file => !isSafeRelativeFilePath(file))
-  if (unsafePath) {
-    return { skipped: makeSkip(input.packageInfo.packageName, skillName, `legacy well-known skill contains unsafe file path "${unsafePath}"`) }
-  }
-
-  const origin = new URL(input.docsUrl).origin
-  const targetDir = join(
-    input.cacheRoot,
-    'well-known',
-    'legacy',
-    sanitizeSegment(origin),
-    sanitizeSegment(input.packageInfo.packageName),
-    sanitizeSegment(input.packageInfo.version || 'unknown'),
-    sanitizeSegment(skillName),
-  )
-
-  await emptyDir(targetDir)
-
-  for (const file of files) {
-    const fileUrl = new URL(`${encodeURIComponent(skillName)}/${encodeRelativePath(file)}`, input.indexUrl).toString()
-    const response = await fetchUrlBytes(fileUrl, input.timeoutMs)
-    if (!response.ok || !response.data) {
-      return { skipped: makeSkip(input.packageInfo.packageName, skillName, `failed to fetch legacy well-known skill file "${file}"`) }
-    }
-    await writeSkillFile(targetDir, file, response.data)
-  }
-
-  return {
-    contribution: contributionFor({
-      packageInfo: input.packageInfo,
-      targetDir,
-      skillName,
-      description,
-      docsUrl: input.docsUrl,
-      resolver: 'wellKnownLegacy',
-      indexUrl: input.indexUrl,
-    }),
-  }
-}
-
-async function resolveLegacyIndex(input: {
-  packageInfo: InstalledPackageInfo
-  index: LegacyIndex
-  indexUrl: string
-  docsUrl: string
-  cacheRoot: string
-  timeoutMs: number
-}): Promise<RemoteResolveResult> {
-  const skipped: SkillManifestSkipped[] = []
-  const contributions: ResolvedContribution[] = []
-
-  if (!Array.isArray(input.index.skills)) {
-    return {
-      contributions: [],
-      issues: [],
-      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'legacy well-known index is missing a skills array')],
-    }
-  }
-
-  for (const rawEntry of input.index.skills) {
-    if (!rawEntry || typeof rawEntry !== 'object') {
-      skipped.push(makeSkip(input.packageInfo.packageName, 'entry', 'legacy well-known skill entry must be an object'))
-      continue
-    }
-
-    const materialized = await materializeLegacySkill({
-      packageInfo: input.packageInfo,
-      entry: rawEntry as LegacySkillEntry,
-      indexUrl: input.indexUrl,
-      docsUrl: input.docsUrl,
-      cacheRoot: input.cacheRoot,
-      timeoutMs: input.timeoutMs,
-    })
-
-    if (materialized?.contribution) {
-      contributions.push(materialized.contribution)
-    }
-    if (materialized?.skipped) {
-      skipped.push(materialized.skipped)
-    }
-  }
-
-  return { contributions, issues: [], skipped }
 }
 
 async function materializeRfcSkill(input: {
@@ -490,7 +354,7 @@ async function resolveIndex(input: {
   cacheRoot: string
   timeoutMs: number
 }): Promise<RemoteResolveResult | null> {
-  const response = await fetchUrlJson<LegacyIndex | RfcIndex>(input.indexUrl, input.timeoutMs)
+  const response = await fetchUrlJson<RfcIndex>(input.indexUrl, input.timeoutMs)
   if (!response.ok) {
     if (response.status === 404) {
       return null
@@ -527,10 +391,11 @@ async function resolveIndex(input: {
     }
   }
 
-  return await resolveLegacyIndex({
-    ...input,
-    index,
-  })
+  return {
+    contributions: [],
+    issues: [],
+    skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'well-known index is missing a supported schema')],
+  }
 }
 
 export async function resolveViaWellKnown(
@@ -543,29 +408,27 @@ export async function resolveViaWellKnown(
   const issues: ValidationIssue[] = []
 
   for (const docsUrl of bases) {
-    for (const path of ['/.well-known/agent-skills/index.json', '/.well-known/skills/index.json']) {
-      const indexUrl = new URL(path, docsUrl).toString()
-      const result = await resolveIndex({
-        packageInfo,
-        indexUrl,
-        docsUrl,
-        cacheRoot,
-        timeoutMs,
-      })
+    const indexUrl = new URL('/.well-known/agent-skills/index.json', docsUrl).toString()
+    const result = await resolveIndex({
+      packageInfo,
+      indexUrl,
+      docsUrl,
+      cacheRoot,
+      timeoutMs,
+    })
 
-      if (!result) {
-        continue
-      }
+    if (!result) {
+      continue
+    }
 
-      issues.push(...result.issues)
-      skipped.push(...result.skipped)
+    issues.push(...result.issues)
+    skipped.push(...result.skipped)
 
-      if (result.contributions.length) {
-        return {
-          contributions: result.contributions,
-          issues,
-          skipped,
-        }
+    if (result.contributions.length) {
+      return {
+        contributions: result.contributions,
+        issues,
+        skipped,
       }
     }
   }

--- a/src/well-known-resolver.ts
+++ b/src/well-known-resolver.ts
@@ -1,0 +1,478 @@
+import { createHash } from 'node:crypto'
+import { promises as fsp } from 'node:fs'
+import { dirname, join } from 'pathe'
+import { findPackageOverride } from './package-overrides'
+import { fetchUrlBytes, fetchUrlJson, parseGitHubRepo } from './remote-fetch'
+import { emptyDir, ensureDir, isValidSkillName, normalizeContribution, sanitizeSegment } from './internal'
+import type { InstalledPackageInfo, RemoteResolveResult } from './remote-resolver'
+import type { ResolvedContribution, SkillManifestSkipped, ValidationIssue } from './types'
+
+const RFC_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
+
+interface LegacySkillEntry {
+  name?: unknown
+  description?: unknown
+  files?: unknown
+}
+
+interface LegacyIndex {
+  $schema?: unknown
+  skills?: unknown
+}
+
+interface RfcSkillEntry {
+  name?: unknown
+  type?: unknown
+  description?: unknown
+  url?: unknown
+  digest?: unknown
+}
+
+interface RfcIndex {
+  $schema?: unknown
+  skills?: unknown
+}
+
+interface MaterializedSkill {
+  contribution?: ResolvedContribution
+  skipped?: SkillManifestSkipped
+}
+
+function makeSkip(packageName: string, skillName: string, reason: string): SkillManifestSkipped {
+  return {
+    packageName,
+    skillName,
+    reason,
+    sourceKind: 'wellKnown',
+  }
+}
+
+function normalizeHttpUrl(url: string | undefined): string | undefined {
+  const trimmed = url?.trim()
+  if (!trimmed) {
+    return undefined
+  }
+
+  try {
+    const parsed = new URL(trimmed)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.toString()
+      : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+function isDocsDiscoveryBase(url: string): boolean {
+  const parsed = new URL(url)
+  if (parsed.hostname === 'github.com' || parseGitHubRepo(url)) {
+    return false
+  }
+
+  return true
+}
+
+function docsBaseCandidates(packageInfo: InstalledPackageInfo): string[] {
+  const override = findPackageOverride(packageInfo.packageName)
+  const candidates = [
+    ...(override?.docsUrls || []),
+    packageInfo.homepage || '',
+  ]
+
+  return [...new Set(candidates
+    .map(normalizeHttpUrl)
+    .filter((url): url is string => Boolean(url))
+    .filter(isDocsDiscoveryBase))]
+}
+
+function isSafeRelativeFilePath(path: string): boolean {
+  if (!path || path.includes('\0') || path.includes('\\') || path.startsWith('/')) {
+    return false
+  }
+
+  const parts = path.split('/')
+  return parts.every(part => part && part !== '.' && part !== '..')
+}
+
+function encodeRelativePath(path: string): string {
+  return path.split('/').map(part => encodeURIComponent(part)).join('/')
+}
+
+function normalizeDigest(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return /^sha256:[a-f0-9]{64}$/.test(trimmed) ? trimmed : null
+}
+
+function sha256(bytes: Uint8Array): string {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+}
+
+async function writeSkillFile(root: string, relativePath: string, bytes: Uint8Array): Promise<void> {
+  const destination = join(root, relativePath)
+  await ensureDir(dirname(destination))
+  await fsp.writeFile(destination, bytes)
+}
+
+function contributionFor(input: {
+  packageInfo: InstalledPackageInfo
+  targetDir: string
+  skillName: string
+  description?: string
+  docsUrl: string
+  resolver: 'wellKnownRfc' | 'wellKnownLegacy'
+  indexUrl: string
+}): ResolvedContribution {
+  const sourceRepo = parseGitHubRepo(input.packageInfo.repository)
+
+  return normalizeContribution({
+    packageName: input.packageInfo.packageName,
+    version: input.packageInfo.version,
+    sourceDir: input.targetDir,
+    skillName: input.skillName,
+    description: input.description,
+    sourceKind: 'wellKnown',
+    sourceRepo: sourceRepo || undefined,
+    sourcePath: input.indexUrl,
+    repoUrl: sourceRepo ? `https://github.com/${sourceRepo}` : undefined,
+    docsUrl: input.docsUrl,
+    official: true,
+    resolver: input.resolver,
+    forceIncludeScripts: true,
+  }, input.targetDir, join(input.targetDir, '..'))
+}
+
+async function materializeLegacySkill(input: {
+  packageInfo: InstalledPackageInfo
+  entry: LegacySkillEntry
+  indexUrl: string
+  docsUrl: string
+  cacheRoot: string
+  timeoutMs: number
+}): Promise<MaterializedSkill | null> {
+  const skillName = typeof input.entry.name === 'string' ? input.entry.name.trim() : ''
+  if (!isValidSkillName(skillName)) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName || 'entry', 'legacy well-known skill name is invalid') }
+  }
+
+  const description = typeof input.entry.description === 'string' ? input.entry.description.trim() : ''
+  if (!description) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'legacy well-known skill is missing a description') }
+  }
+
+  if (!Array.isArray(input.entry.files) || !input.entry.files.every(file => typeof file === 'string')) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'legacy well-known skill files must be a string array') }
+  }
+
+  const files = input.entry.files.map(file => file.trim())
+  if (!files.includes('SKILL.md')) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'legacy well-known skill must include SKILL.md') }
+  }
+
+  const unsafePath = files.find(file => !isSafeRelativeFilePath(file))
+  if (unsafePath) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, `legacy well-known skill contains unsafe file path "${unsafePath}"`) }
+  }
+
+  const origin = new URL(input.docsUrl).origin
+  const targetDir = join(
+    input.cacheRoot,
+    'well-known',
+    'legacy',
+    sanitizeSegment(origin),
+    sanitizeSegment(input.packageInfo.packageName),
+    sanitizeSegment(input.packageInfo.version || 'unknown'),
+    sanitizeSegment(skillName),
+  )
+
+  await emptyDir(targetDir)
+
+  for (const file of files) {
+    const fileUrl = new URL(`${encodeURIComponent(skillName)}/${encodeRelativePath(file)}`, input.indexUrl).toString()
+    const response = await fetchUrlBytes(fileUrl, input.timeoutMs)
+    if (!response.ok || !response.data) {
+      return { skipped: makeSkip(input.packageInfo.packageName, skillName, `failed to fetch legacy well-known skill file "${file}"`) }
+    }
+    await writeSkillFile(targetDir, file, response.data)
+  }
+
+  return {
+    contribution: contributionFor({
+      packageInfo: input.packageInfo,
+      targetDir,
+      skillName,
+      description,
+      docsUrl: input.docsUrl,
+      resolver: 'wellKnownLegacy',
+      indexUrl: input.indexUrl,
+    }),
+  }
+}
+
+async function resolveLegacyIndex(input: {
+  packageInfo: InstalledPackageInfo
+  index: LegacyIndex
+  indexUrl: string
+  docsUrl: string
+  cacheRoot: string
+  timeoutMs: number
+}): Promise<RemoteResolveResult> {
+  const skipped: SkillManifestSkipped[] = []
+  const contributions: ResolvedContribution[] = []
+
+  if (!Array.isArray(input.index.skills)) {
+    return {
+      contributions: [],
+      issues: [],
+      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'legacy well-known index is missing a skills array')],
+    }
+  }
+
+  for (const rawEntry of input.index.skills) {
+    if (!rawEntry || typeof rawEntry !== 'object') {
+      skipped.push(makeSkip(input.packageInfo.packageName, 'entry', 'legacy well-known skill entry must be an object'))
+      continue
+    }
+
+    const materialized = await materializeLegacySkill({
+      packageInfo: input.packageInfo,
+      entry: rawEntry as LegacySkillEntry,
+      indexUrl: input.indexUrl,
+      docsUrl: input.docsUrl,
+      cacheRoot: input.cacheRoot,
+      timeoutMs: input.timeoutMs,
+    })
+
+    if (materialized?.contribution) {
+      contributions.push(materialized.contribution)
+    }
+    if (materialized?.skipped) {
+      skipped.push(materialized.skipped)
+    }
+  }
+
+  return { contributions, issues: [], skipped }
+}
+
+async function materializeRfcSkill(input: {
+  packageInfo: InstalledPackageInfo
+  entry: RfcSkillEntry
+  indexUrl: string
+  docsUrl: string
+  cacheRoot: string
+  timeoutMs: number
+}): Promise<MaterializedSkill | null> {
+  const skillName = typeof input.entry.name === 'string' ? input.entry.name.trim() : ''
+  if (!isValidSkillName(skillName)) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName || 'entry', 'RFC well-known skill name is invalid') }
+  }
+
+  const description = typeof input.entry.description === 'string' ? input.entry.description.trim() : ''
+  if (!description) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill is missing a description') }
+  }
+
+  const type = typeof input.entry.type === 'string' ? input.entry.type.trim() : ''
+  if (type === 'archive') {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'archive artifacts are not supported yet') }
+  }
+  if (type !== 'skill-md') {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, `unsupported RFC well-known skill type "${type || 'unknown'}"`) }
+  }
+
+  if (typeof input.entry.url !== 'string' || !input.entry.url.trim()) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill is missing a URL') }
+  }
+
+  const digest = normalizeDigest(input.entry.digest)
+  if (!digest) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill is missing a valid sha256 digest') }
+  }
+
+  const skillUrl = new URL(input.entry.url, input.indexUrl).toString()
+  const response = await fetchUrlBytes(skillUrl, input.timeoutMs)
+  if (!response.ok || !response.data) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'failed to fetch RFC well-known skill artifact') }
+  }
+
+  if (sha256(response.data) !== digest) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'RFC well-known skill digest mismatch') }
+  }
+
+  const origin = new URL(input.docsUrl).origin
+  const targetDir = join(
+    input.cacheRoot,
+    'well-known',
+    'rfc',
+    sanitizeSegment(origin),
+    sanitizeSegment(input.packageInfo.packageName),
+    sanitizeSegment(input.packageInfo.version || 'unknown'),
+    sanitizeSegment(skillName),
+  )
+
+  await emptyDir(targetDir)
+  await writeSkillFile(targetDir, 'SKILL.md', response.data)
+
+  return {
+    contribution: contributionFor({
+      packageInfo: input.packageInfo,
+      targetDir,
+      skillName,
+      description,
+      docsUrl: input.docsUrl,
+      resolver: 'wellKnownRfc',
+      indexUrl: input.indexUrl,
+    }),
+  }
+}
+
+async function resolveRfcIndex(input: {
+  packageInfo: InstalledPackageInfo
+  index: RfcIndex
+  indexUrl: string
+  docsUrl: string
+  cacheRoot: string
+  timeoutMs: number
+}): Promise<RemoteResolveResult> {
+  const skipped: SkillManifestSkipped[] = []
+  const contributions: ResolvedContribution[] = []
+
+  if (!Array.isArray(input.index.skills)) {
+    return {
+      contributions: [],
+      issues: [],
+      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'RFC well-known index is missing a skills array')],
+    }
+  }
+
+  for (const rawEntry of input.index.skills) {
+    if (!rawEntry || typeof rawEntry !== 'object') {
+      skipped.push(makeSkip(input.packageInfo.packageName, 'entry', 'RFC well-known skill entry must be an object'))
+      continue
+    }
+
+    const materialized = await materializeRfcSkill({
+      packageInfo: input.packageInfo,
+      entry: rawEntry as RfcSkillEntry,
+      indexUrl: input.indexUrl,
+      docsUrl: input.docsUrl,
+      cacheRoot: input.cacheRoot,
+      timeoutMs: input.timeoutMs,
+    })
+
+    if (materialized?.contribution) {
+      contributions.push(materialized.contribution)
+    }
+    if (materialized?.skipped) {
+      skipped.push(materialized.skipped)
+    }
+  }
+
+  return { contributions, issues: [], skipped }
+}
+
+async function resolveIndex(input: {
+  packageInfo: InstalledPackageInfo
+  indexUrl: string
+  docsUrl: string
+  cacheRoot: string
+  timeoutMs: number
+}): Promise<RemoteResolveResult | null> {
+  const response = await fetchUrlJson<LegacyIndex | RfcIndex>(input.indexUrl, input.timeoutMs)
+  if (!response.ok) {
+    if (response.status === 404) {
+      return null
+    }
+
+    return {
+      contributions: [],
+      issues: [],
+      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, `failed to fetch well-known index ${input.indexUrl}`)],
+    }
+  }
+
+  const index = response.data
+  if (!index || typeof index !== 'object') {
+    return {
+      contributions: [],
+      issues: [],
+      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'well-known index must be an object')],
+    }
+  }
+
+  if (index.$schema === RFC_SCHEMA) {
+    return await resolveRfcIndex({
+      ...input,
+      index,
+    })
+  }
+
+  if (typeof index.$schema === 'string' && index.$schema) {
+    return {
+      contributions: [],
+      issues: [],
+      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, `unsupported well-known schema "${index.$schema}"`)],
+    }
+  }
+
+  return await resolveLegacyIndex({
+    ...input,
+    index,
+  })
+}
+
+export async function resolveViaWellKnown(
+  packageInfo: InstalledPackageInfo,
+  cacheRoot: string,
+  timeoutMs: number,
+): Promise<RemoteResolveResult> {
+  const bases = docsBaseCandidates(packageInfo)
+  const skipped: SkillManifestSkipped[] = []
+  const issues: ValidationIssue[] = []
+
+  for (const docsUrl of bases) {
+    for (const path of ['/.well-known/agent-skills/index.json', '/.well-known/skills/index.json']) {
+      const indexUrl = new URL(path, docsUrl).toString()
+      const result = await resolveIndex({
+        packageInfo,
+        indexUrl,
+        docsUrl,
+        cacheRoot,
+        timeoutMs,
+      })
+
+      if (!result) {
+        continue
+      }
+
+      issues.push(...result.issues)
+      skipped.push(...result.skipped)
+
+      if (result.contributions.length) {
+        return {
+          contributions: result.contributions,
+          issues,
+          skipped,
+        }
+      }
+    }
+  }
+
+  if (!bases.length) {
+    return {
+      contributions: [],
+      issues: [],
+      skipped: [],
+    }
+  }
+
+  return {
+    contributions: [],
+    issues,
+    skipped,
+  }
+}

--- a/test/core-content.test.ts
+++ b/test/core-content.test.ts
@@ -151,7 +151,7 @@ Source code: [https://github.com/nuxt-modules/i18n](https://github.com/nuxt-modu
         docsUrl: 'https://docus.dev/',
         official: true,
         trustLevel: 'official' as const,
-        resolver: 'wellKnownLegacy' as const,
+        resolver: 'wellKnownRfc' as const,
         wrapperPath: 'references/modules/docus/create-docs.md',
       },
     ])

--- a/test/core-content.test.ts
+++ b/test/core-content.test.ts
@@ -151,7 +151,7 @@ Source code: [https://github.com/nuxt-modules/i18n](https://github.com/nuxt-modu
         docsUrl: 'https://docus.dev/',
         official: true,
         trustLevel: 'official' as const,
-        resolver: 'wellKnownRfc' as const,
+        resolver: 'wellKnownV2' as const,
         wrapperPath: 'references/modules/docus/create-docs.md',
       },
     ])

--- a/test/core-content.test.ts
+++ b/test/core-content.test.ts
@@ -1,26 +1,26 @@
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { loadCoreMetadata } from '../src/core-content'
+import { loadNuxtMetadata } from '../src/nuxt-content'
 import { PACKAGE_VERSION } from '../src/package-info'
 import { loadVueSkillFiles } from '../src/vue-content'
 import {
   createModuleWrapperContent,
   createSkillEntrypoint,
   createStableSkillWrapper,
-  DEFAULT_CORE_CONTENT_METADATA,
+  DEFAULT_NUXT_CONTENT_METADATA,
 } from '../src/render-content'
 
 const testCacheRoot = join(tmpdir(), 'skill-hub-test-vue')
 
 describe('createSkillEntrypoint', () => {
   it('loads core metadata from the in-code default source', async () => {
-    await expect(loadCoreMetadata()).resolves.toEqual(DEFAULT_CORE_CONTENT_METADATA)
-    expect(DEFAULT_CORE_CONTENT_METADATA.version).toBe(PACKAGE_VERSION)
+    await expect(loadNuxtMetadata()).resolves.toEqual(DEFAULT_NUXT_CONTENT_METADATA)
+    expect(DEFAULT_NUXT_CONTENT_METADATA.version).toBe(PACKAGE_VERSION)
   })
 
   it('omits the monorepo scope section for standalone apps', () => {
-    const entry = createSkillEntrypoint('nuxt', DEFAULT_CORE_CONTENT_METADATA)
+    const entry = createSkillEntrypoint('nuxt', DEFAULT_NUXT_CONTENT_METADATA)
 
     expect(entry).toContain('# Nuxt Skill Router')
     expect(entry).toContain('## Loading rules')
@@ -55,7 +55,7 @@ describe('createSkillEntrypoint', () => {
   })
 
   it('renders a hard monorepo scope warning when a scope path is provided', () => {
-    const entry = createSkillEntrypoint('nuxt-web', DEFAULT_CORE_CONTENT_METADATA, 'apps/web')
+    const entry = createSkillEntrypoint('nuxt-web', DEFAULT_NUXT_CONTENT_METADATA, 'apps/web')
 
     expect(entry).toContain('## Monorepo scope')
     expect(entry).toContain('`apps/web`')
@@ -64,7 +64,7 @@ describe('createSkillEntrypoint', () => {
   })
 
   it('prioritizes the eval-derived disambiguation packs', () => {
-    expect(DEFAULT_CORE_CONTENT_METADATA.packIds.slice(0, 4)).toEqual([
+    expect(DEFAULT_NUXT_CONTENT_METADATA.packIds.slice(0, 4)).toEqual([
       'abstraction-disambiguation',
       'page-meta-head-layout',
       'error-surfaces-recovery',
@@ -73,14 +73,14 @@ describe('createSkillEntrypoint', () => {
   })
 
   it('keeps the default skill app-oriented when module authoring is disabled', () => {
-    const entry = createSkillEntrypoint('nuxt', DEFAULT_CORE_CONTENT_METADATA)
+    const entry = createSkillEntrypoint('nuxt', DEFAULT_NUXT_CONTENT_METADATA)
 
     expect(entry).not.toContain('"Add a Nuxt module option, hook, or runtime extension"')
     expect(entry).not.toContain('Writing or refactoring a Nuxt module')
   })
 
   it('layers module-author guidance on top of the default skill', () => {
-    const entry = createSkillEntrypoint('nuxt', DEFAULT_CORE_CONTENT_METADATA, undefined, true)
+    const entry = createSkillEntrypoint('nuxt', DEFAULT_NUXT_CONTENT_METADATA, undefined, true)
 
     expect(entry).toContain('Module Authoring Conventions')
     expect(entry).toContain('Writing or refactoring a Nuxt module (`defineNuxtModule`, hooks, public APIs)')
@@ -114,7 +114,7 @@ Source code: [https://github.com/nuxt-modules/i18n](https://github.com/nuxt-modu
   })
 
   it('uses neutral labels for resolved module skills and omits missing versions in module lists', () => {
-    const entry = createSkillEntrypoint('nuxt', DEFAULT_CORE_CONTENT_METADATA, undefined, false, [
+    const entry = createSkillEntrypoint('nuxt', DEFAULT_NUXT_CONTENT_METADATA, undefined, false, [
       {
         packageName: '@nuxthub/core',
         version: undefined,
@@ -139,7 +139,7 @@ Source code: [https://github.com/nuxt-modules/i18n](https://github.com/nuxt-modu
   })
 
   it('renders docs-discovered module skills in their own group', () => {
-    const entry = createSkillEntrypoint('nuxt', DEFAULT_CORE_CONTENT_METADATA, undefined, false, [
+    const entry = createSkillEntrypoint('nuxt', DEFAULT_NUXT_CONTENT_METADATA, undefined, false, [
       {
         packageName: 'docus',
         version: '5.9.0',

--- a/test/core-content.test.ts
+++ b/test/core-content.test.ts
@@ -137,6 +137,28 @@ Source code: [https://github.com/nuxt-modules/i18n](https://github.com/nuxt-modu
     expect(entry).not.toContain('GitHub-resolved')
     expect(entry).not.toContain('`unknown`')
   })
+
+  it('renders docs-discovered module skills in their own group', () => {
+    const entry = createSkillEntrypoint('nuxt', DEFAULT_CORE_CONTENT_METADATA, undefined, false, [
+      {
+        packageName: 'docus',
+        version: '5.9.0',
+        skillName: 'create-docs',
+        description: 'Create Docus documentation.',
+        scriptsIncluded: true,
+        sourceKind: 'wellKnown' as const,
+        sourceLabel: 'Docs-discovered skill',
+        docsUrl: 'https://docus.dev/',
+        official: true,
+        trustLevel: 'official' as const,
+        resolver: 'wellKnownLegacy' as const,
+        wrapperPath: 'references/modules/docus/create-docs.md',
+      },
+    ])
+
+    expect(entry).toContain('### Docs-discovered skills')
+    expect(entry).toContain('[docus](./references/modules/docus/create-docs.md) `v5.9.0` - Docs-discovered skill. Trust: `official`.')
+  })
 })
 
 describe('createStableSkillWrapper', () => {

--- a/test/remote-fetch.test.ts
+++ b/test/remote-fetch.test.ts
@@ -61,4 +61,52 @@ describe('remote fetch memoization', () => {
     expect(await listGitHubDirectory('onmax/nuxt-skills', 'main', 'skills', 200)).toEqual(['nuxt-seo', 'nuxt-ui'])
     expect(ofetchMock).toHaveBeenCalledTimes(2)
   })
+
+  it('memoizes generic URL text, JSON, and byte fetches per URL', async () => {
+    const ofetchMock = vi.fn(async (url: string, options?: { responseType?: string }) => {
+      if (options?.responseType === 'arrayBuffer') {
+        return new Uint8Array([1, 2, 3]).buffer
+      }
+
+      if (url.endsWith('.json')) {
+        return '{"ok":true}'
+      }
+
+      return 'hello'
+    })
+
+    vi.resetModules()
+    vi.doMock('ofetch', () => ({
+      ofetch: ofetchMock,
+    }))
+
+    const { fetchUrlBytes, fetchUrlJson, fetchUrlText } = await import('../src/remote-fetch')
+
+    await fetchUrlText('https://example.com/skill.md', 200)
+    await fetchUrlText('https://example.com/skill.md', 400)
+    await fetchUrlJson<{ ok: boolean }>('https://example.com/index.json', 200)
+    await fetchUrlJson<{ ok: boolean }>('https://example.com/index.json', 400)
+    await fetchUrlBytes('https://example.com/skill.tar.gz', 200)
+    await fetchUrlBytes('https://example.com/skill.tar.gz', 400)
+
+    expect(ofetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns non-throwing status details for generic URL 404s', async () => {
+    const ofetchMock = vi.fn(async () => {
+      throw Object.assign(new Error('Not Found'), { status: 404 })
+    })
+
+    vi.resetModules()
+    vi.doMock('ofetch', () => ({
+      ofetch: ofetchMock,
+    }))
+
+    const { fetchUrlText } = await import('../src/remote-fetch')
+
+    await expect(fetchUrlText('https://example.com/missing', 200)).resolves.toMatchObject({
+      ok: false,
+      status: 404,
+    })
+  })
 })

--- a/test/remote-resolver.test.ts
+++ b/test/remote-resolver.test.ts
@@ -304,7 +304,7 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(fetchUrlJsonMock).not.toHaveBeenCalled()
   })
 
-  it('skips RFC well-known skill-md entries whose artifact URL leaves the discovery origin', async () => {
+  it('skips well-known v2 skill-md entries whose artifact URL leaves the discovery origin', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
 
@@ -353,16 +353,16 @@ describe('resolveRemoteContributionsForPackage', () => {
 
     expect(result.contributions).toHaveLength(1)
     expect(result.contributions[0]?.sourceKind).toBe('generated')
-    expect(result.skipped.some(entry => entry.reason === 'RFC well-known skill URL must stay on the discovery origin')).toBe(true)
+    expect(result.skipped.some(entry => entry.reason === 'well-known v2 skill URL must stay on the discovery origin')).toBe(true)
     expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
-  it('does not probe v0.1 discovery indexes', async () => {
+  it('only probes well-known v2 discovery indexes', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const v1IndexUrl = `https://docs.example.com/.well-known/${'skills'}/index.json`
     const fetchUrlJsonMock = vi.fn(async (url: string) => {
       if (url === v1IndexUrl) {
-        throw new Error('v0.1 endpoint should not be fetched')
+        throw new Error('legacy endpoint should not be fetched')
       }
 
       return { ok: false, status: 404 }
@@ -401,7 +401,7 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(fetchUrlJsonMock).toHaveBeenCalledWith('https://docs.example.com/.well-known/agent-skills/index.json', 200)
   })
 
-  it('skips schema-less well-known indexes and falls back', async () => {
+  it('skips schema-less well-known indexes instead of treating them as legacy discovery', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
 
@@ -447,11 +447,11 @@ describe('resolveRemoteContributionsForPackage', () => {
 
     expect(result.contributions).toHaveLength(1)
     expect(result.contributions[0]?.sourceKind).toBe('generated')
-    expect(result.skipped.some(entry => entry.reason === 'well-known index is missing a supported schema')).toBe(true)
+    expect(result.skipped.some(entry => entry.reason === 'well-known index is missing the v2 schema')).toBe(true)
     expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
-  it('resolves RFC well-known skill-md entries and verifies digests', async () => {
+  it('resolves well-known v2 skill-md entries and verifies digests', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const skill = skillMarkdown('docs-sdk', 'Use the SDK docs.')
 
@@ -501,11 +501,11 @@ describe('resolveRemoteContributionsForPackage', () => {
 
     expect(result.contributions).toHaveLength(1)
     expect(result.contributions[0]?.sourceKind).toBe('wellKnown')
-    expect(result.contributions[0]?.resolver).toBe('wellKnownRfc')
+    expect(result.contributions[0]?.resolver).toBe('wellKnownV2')
     await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'SKILL.md'), 'utf8')).resolves.toBe(skill)
   })
 
-  it('skips RFC well-known skill-md entries with invalid digest formats and falls back', async () => {
+  it('skips well-known v2 skill-md entries with invalid digest formats and falls back', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
 
@@ -553,11 +553,11 @@ describe('resolveRemoteContributionsForPackage', () => {
 
     expect(result.contributions).toHaveLength(1)
     expect(result.contributions[0]?.sourceKind).toBe('generated')
-    expect(result.skipped.some(entry => entry.reason === 'RFC well-known skill is missing a valid sha256 digest')).toBe(true)
+    expect(result.skipped.some(entry => entry.reason === 'well-known v2 skill is missing a valid sha256 digest')).toBe(true)
     expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
-  it('skips RFC well-known skill-md entries with digest mismatches and falls back', async () => {
+  it('skips well-known v2 skill-md entries with digest mismatches and falls back', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const skill = skillMarkdown('docs-sdk', 'Use the SDK docs.')
 
@@ -612,7 +612,7 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(result.skipped.some(entry => entry.sourceKind === 'wellKnown' && entry.reason.includes('digest mismatch'))).toBe(true)
   })
 
-  it('skips RFC archive entries until archive extraction is supported', async () => {
+  it('skips well-known v2 archive entries until archive extraction is supported', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
 
     vi.resetModules()

--- a/test/remote-resolver.test.ts
+++ b/test/remote-resolver.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { promises as fsp } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -7,6 +8,14 @@ function createSkillFiles(destinationDir: string, skillName: string): Promise<vo
   const content = `---\nname: ${skillName}\ndescription: test\n---\n`
   return fsp.mkdir(destinationDir, { recursive: true })
     .then(() => fsp.writeFile(join(destinationDir, 'SKILL.md'), content, 'utf8'))
+}
+
+function skillMarkdown(skillName: string, description = 'test'): string {
+  return `---\nname: ${skillName}\ndescription: ${description}\n---\n`
+}
+
+function sha256(content: string): string {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`
 }
 
 function mockDownloadTemplate(impl: (input: string, dir: string) => Promise<void>) {
@@ -41,6 +50,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
       listGitHubDirectory: vi.fn(async () => ['reka-ui']),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
       downloadTemplate: downloadMock,
@@ -77,6 +88,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
       listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
       downloadTemplate: downloadMock,
@@ -119,6 +132,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       parseGitHubRepo: vi.fn((input: string) => input || null),
       fetchGitHubDefaultBranch: defaultBranchMock,
       listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
       fetchGitHubFileText: vi.fn(async () => ({
         ok: true,
         status: 200,
@@ -153,6 +168,307 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(defaultBranchMock).not.toHaveBeenCalled()
   })
 
+  it('resolves Docus legacy well-known skills via docs URL override', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const downloadMock = mockDownloadTemplate(async () => {
+      throw new Error('not found')
+    })
+    const defaultBranchMock = vi.fn(async () => 'main')
+    const listGitHubDirectoryMock = vi.fn(async () => [])
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn((input: string | undefined) => {
+        if (!input) return null
+        if (input === 'nuxt-content/docus') return input
+        if (input.includes('github.com/nuxt-content/docus')) return 'nuxt-content/docus'
+        return null
+      }),
+      fetchGitHubDefaultBranch: defaultBranchMock,
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: listGitHubDirectoryMock,
+      fetchUrlJson: vi.fn(async (url: string) => {
+        if (url === 'https://docus.dev/.well-known/agent-skills/index.json') {
+          return { ok: false, status: 404 }
+        }
+
+        if (url === 'https://docus.dev/.well-known/skills/index.json') {
+          return {
+            ok: true,
+            data: {
+              skills: [
+                {
+                  name: 'create-docs',
+                  description: 'Create docs.',
+                  files: ['SKILL.md', 'references/templates.md'],
+                },
+                {
+                  name: 'review-docs',
+                  description: 'Review docs.',
+                  files: ['SKILL.md'],
+                },
+              ],
+            },
+          }
+        }
+
+        return { ok: false, status: 404 }
+      }),
+      fetchUrlBytes: vi.fn(async (url: string) => {
+        const files: Record<string, string> = {
+          'https://docus.dev/.well-known/skills/create-docs/SKILL.md': skillMarkdown('create-docs', 'Create docs.'),
+          'https://docus.dev/.well-known/skills/create-docs/references/templates.md': '# Templates\n',
+          'https://docus.dev/.well-known/skills/review-docs/SKILL.md': skillMarkdown('review-docs', 'Review docs.'),
+        }
+
+        const content = files[url]
+        return content
+          ? { ok: true, data: Buffer.from(content) }
+          : { ok: false, status: 404 }
+      }),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: downloadMock,
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docus',
+      version: '5.9.0',
+      repository: 'git+https://github.com/nuxt-content/docus.git',
+      homepage: 'https://github.com/nuxt-content/docus#readme',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(2)
+    expect(result.contributions.map(item => item.skillName)).toEqual(['create-docs', 'review-docs'])
+    expect(result.contributions.every(item => item.sourceKind === 'wellKnown')).toBe(true)
+    expect(result.contributions.every(item => item.resolver === 'wellKnownLegacy')).toBe(true)
+    expect(result.contributions[0]?.docsUrl).toBe('https://docus.dev/')
+    await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'references/templates.md'), 'utf8')).resolves.toBe('# Templates\n')
+    expect(defaultBranchMock).not.toHaveBeenCalled()
+    expect(listGitHubDirectoryMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves RFC well-known skill-md entries and verifies digests', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const skill = skillMarkdown('docs-sdk', 'Use the SDK docs.')
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => url === 'https://docs.example.com/.well-known/agent-skills/index.json'
+        ? {
+            ok: true,
+            data: {
+              $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  type: 'skill-md',
+                  description: 'Use the SDK docs.',
+                  url: '/.well-known/agent-skills/docs-sdk/SKILL.md',
+                  digest: sha256(skill),
+                },
+              ],
+            },
+          }
+        : { ok: false, status: 404 }),
+      fetchUrlBytes: vi.fn(async (url: string) => url === 'https://docs.example.com/.well-known/agent-skills/docs-sdk/SKILL.md'
+        ? { ok: true, data: Buffer.from(skill) }
+        : { ok: false, status: 404 }),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('wellKnown')
+    expect(result.contributions[0]?.resolver).toBe('wellKnownRfc')
+    await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'SKILL.md'), 'utf8')).resolves.toBe(skill)
+  })
+
+  it('skips RFC well-known skill-md entries with digest mismatches and falls back', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const skill = skillMarkdown('docs-sdk', 'Use the SDK docs.')
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => {
+        if (url === 'https://docs.example.com/.well-known/agent-skills/index.json') {
+          return {
+            ok: true,
+            data: {
+              $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  type: 'skill-md',
+                  description: 'Use the SDK docs.',
+                  url: '/.well-known/agent-skills/docs-sdk/SKILL.md',
+                  digest: `sha256:${'0'.repeat(64)}`,
+                },
+              ],
+            },
+          }
+        }
+
+        return { ok: false, status: 404 }
+      }),
+      fetchUrlBytes: vi.fn(async () => ({ ok: true, data: Buffer.from(skill) })),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(result.skipped.some(entry => entry.sourceKind === 'wellKnown' && entry.reason.includes('digest mismatch'))).toBe(true)
+  })
+
+  it('skips RFC archive entries until archive extraction is supported', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => url === 'https://docs.example.com/.well-known/agent-skills/index.json'
+        ? {
+            ok: true,
+            data: {
+              $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  type: 'archive',
+                  description: 'Use the SDK docs.',
+                  url: '/.well-known/agent-skills/docs-sdk.tar.gz',
+                  digest: `sha256:${'1'.repeat(64)}`,
+                },
+              ],
+            },
+          }
+        : { ok: false, status: 404 }),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(result.skipped.some(entry => entry.reason === 'archive artifacts are not supported yet')).toBe(true)
+  })
+
+  it('rejects unsafe legacy well-known file paths and falls back', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => {
+        if (url === 'https://docs.example.com/.well-known/agent-skills/index.json') {
+          return { ok: false, status: 404 }
+        }
+
+        if (url === 'https://docs.example.com/.well-known/skills/index.json') {
+          return {
+            ok: true,
+            data: {
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  description: 'Use the SDK docs.',
+                  files: ['SKILL.md', '../secret.md'],
+                },
+              ],
+            },
+          }
+        }
+
+        return { ok: false, status: 404 }
+      }),
+      fetchUrlBytes: fetchUrlBytesMock,
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(result.skipped.some(entry => entry.reason.includes('unsafe file path'))).toBe(true)
+    expect(fetchUrlBytesMock).not.toHaveBeenCalled()
+  })
+
   it('discovers all root github skills for docus', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const downloadMock = mockDownloadTemplate(async (input, destinationDir) => {
@@ -174,6 +490,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
       listGitHubDirectory: vi.fn(async () => ['docus', 'create-docs', 'review-docs']),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
       downloadTemplate: downloadMock,
@@ -209,6 +527,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
       listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
       downloadTemplate: downloadMock,
@@ -254,6 +574,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       parseGitHubRepo: vi.fn((input: string) => input || null),
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
       fetchGitHubFileText: vi.fn(async () => ({
         ok: true,
         status: 200,
@@ -313,6 +635,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
       listGitHubDirectory: vi.fn(async () => ['reka-ui']),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
       downloadTemplate: downloadMock,
@@ -354,6 +678,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
       listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
       downloadTemplate: downloadMock,
@@ -403,6 +729,8 @@ describe('resolveRemoteContributionsForPackage', () => {
       fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
       listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
       downloadTemplate: downloadMock,

--- a/test/remote-resolver.test.ts
+++ b/test/remote-resolver.test.ts
@@ -168,6 +168,195 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(defaultBranchMock).not.toHaveBeenCalled()
   })
 
+  it('uses remote package agents.skills on fallback refs before heuristics', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const downloadMock = mockDownloadTemplate(async (input, destinationDir) => {
+      if (input === 'gh:acme/nuxt-module/.agent/skills/nuxt-module#main') {
+        await createSkillFiles(destinationDir, 'nuxt-module')
+        return
+      }
+
+      throw new Error('not found')
+    })
+    const listGitHubDirectoryMock = vi.fn(async () => ['wrong-heuristic'])
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn((input: string) => input || null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      listGitHubDirectory: listGitHubDirectoryMock,
+      fetchUrlJson: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
+      fetchGitHubFileText: vi.fn(async (_repo: string, ref: string) => {
+        if (ref === 'v0.3.0' || ref === '0.3.0') {
+          return { ok: false, status: 404 }
+        }
+
+        if (ref === 'main') {
+          return {
+            ok: true,
+            status: 200,
+            data: JSON.stringify({
+              agents: {
+                skills: [
+                  { name: 'nuxt-module', path: '.agent/skills/nuxt-module' },
+                ],
+              },
+            }),
+          }
+        }
+
+        return { ok: false, status: 404 }
+      }),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: downloadMock,
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: '@acme/nuxt-module',
+      version: '0.3.0',
+      repository: 'acme/nuxt-module',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.resolver).toBe('agentsField')
+    expect(result.contributions[0]?.sourceRef).toBe('main')
+    expect(result.contributions[0]?.sourcePath).toBe('.agent/skills/nuxt-module')
+    expect(listGitHubDirectoryMock).not.toHaveBeenCalled()
+  })
+
+  it('does not probe well-known indexes on localhost homepages', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const fetchUrlJsonMock = vi.fn(async () => ({ ok: false, status: 404 }))
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: fetchUrlJsonMock,
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'local-docs',
+      version: '1.0.0',
+      description: 'Local docs.',
+      homepage: 'http://localhost:3000/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(fetchUrlJsonMock).not.toHaveBeenCalled()
+  })
+
+  it('does not probe well-known indexes on private IPv4 homepages', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const fetchUrlJsonMock = vi.fn(async () => ({ ok: false, status: 404 }))
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: fetchUrlJsonMock,
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'private-docs',
+      version: '1.0.0',
+      description: 'Private docs.',
+      homepage: 'http://192.168.1.10/docs',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(result.contributions[0]?.docsUrl).toBe('http://192.168.1.10/docs')
+    expect(fetchUrlJsonMock).not.toHaveBeenCalled()
+  })
+
+  it('skips RFC well-known skill-md entries whose artifact URL leaves the discovery origin', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => url === 'https://docs.example.com/.well-known/agent-skills/index.json'
+        ? {
+            ok: true,
+            data: {
+              $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  type: 'skill-md',
+                  description: 'Use the SDK docs.',
+                  url: 'https://evil.example.com/SKILL.md',
+                  digest: sha256(skillMarkdown('docs-sdk')),
+                },
+              ],
+            },
+          }
+        : { ok: false, status: 404 }),
+      fetchUrlBytes: fetchUrlBytesMock,
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      description: 'Docs SDK.',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(result.skipped.some(entry => entry.reason === 'RFC well-known skill URL must stay on the discovery origin')).toBe(true)
+    expect(fetchUrlBytesMock).not.toHaveBeenCalled()
+  })
+
   it('resolves Docus legacy well-known skills via docs URL override', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
     const downloadMock = mockDownloadTemplate(async () => {
@@ -249,7 +438,7 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(result.contributions.every(item => item.resolver === 'wellKnownLegacy')).toBe(true)
     expect(result.contributions[0]?.docsUrl).toBe('https://docus.dev/')
     await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'references/templates.md'), 'utf8')).resolves.toBe('# Templates\n')
-    expect(defaultBranchMock).not.toHaveBeenCalled()
+    expect(defaultBranchMock).toHaveBeenCalledWith('nuxt-content/docus', 200)
     expect(listGitHubDirectoryMock).not.toHaveBeenCalled()
   })
 

--- a/test/remote-resolver.test.ts
+++ b/test/remote-resolver.test.ts
@@ -357,89 +357,98 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
-  it('resolves Docus legacy well-known skills via docs URL override', async () => {
+  it('does not probe v0.1 discovery indexes', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
-    const downloadMock = mockDownloadTemplate(async () => {
-      throw new Error('not found')
+    const v1IndexUrl = `https://docs.example.com/.well-known/${'skills'}/index.json`
+    const fetchUrlJsonMock = vi.fn(async (url: string) => {
+      if (url === v1IndexUrl) {
+        throw new Error('v0.1 endpoint should not be fetched')
+      }
+
+      return { ok: false, status: 404 }
     })
-    const defaultBranchMock = vi.fn(async () => 'main')
-    const listGitHubDirectoryMock = vi.fn(async () => [])
 
     vi.resetModules()
     vi.doMock('../src/remote-fetch', () => ({
-      parseGitHubRepo: vi.fn((input: string | undefined) => {
-        if (!input) return null
-        if (input === 'nuxt-content/docus') return input
-        if (input.includes('github.com/nuxt-content/docus')) return 'nuxt-content/docus'
-        return null
-      }),
-      fetchGitHubDefaultBranch: defaultBranchMock,
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
       fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
-      listGitHubDirectory: listGitHubDirectoryMock,
-      fetchUrlJson: vi.fn(async (url: string) => {
-        if (url === 'https://docus.dev/.well-known/agent-skills/index.json') {
-          return { ok: false, status: 404 }
-        }
-
-        if (url === 'https://docus.dev/.well-known/skills/index.json') {
-          return {
-            ok: true,
-            data: {
-              skills: [
-                {
-                  name: 'create-docs',
-                  description: 'Create docs.',
-                  files: ['SKILL.md', 'references/templates.md'],
-                },
-                {
-                  name: 'review-docs',
-                  description: 'Review docs.',
-                  files: ['SKILL.md'],
-                },
-              ],
-            },
-          }
-        }
-
-        return { ok: false, status: 404 }
-      }),
-      fetchUrlBytes: vi.fn(async (url: string) => {
-        const files: Record<string, string> = {
-          'https://docus.dev/.well-known/skills/create-docs/SKILL.md': skillMarkdown('create-docs', 'Create docs.'),
-          'https://docus.dev/.well-known/skills/create-docs/references/templates.md': '# Templates\n',
-          'https://docus.dev/.well-known/skills/review-docs/SKILL.md': skillMarkdown('review-docs', 'Review docs.'),
-        }
-
-        const content = files[url]
-        return content
-          ? { ok: true, data: Buffer.from(content) }
-          : { ok: false, status: 404 }
-      }),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: fetchUrlJsonMock,
+      fetchUrlBytes: vi.fn(async () => ({ ok: false, status: 404 })),
     }))
     vi.doMock('giget', () => ({
-      downloadTemplate: downloadMock,
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
     }))
 
     const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
     const result = await resolveRemoteContributionsForPackage({
-      packageName: 'docus',
-      version: '5.9.0',
-      repository: 'git+https://github.com/nuxt-content/docus.git',
-      homepage: 'https://github.com/nuxt-content/docus#readme',
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      description: 'Docs SDK.',
+      homepage: 'https://docs.example.com/',
     }, {
       cacheRoot,
       githubLookupTimeoutMs: 200,
       enableGithubLookup: true,
     })
 
-    expect(result.contributions).toHaveLength(2)
-    expect(result.contributions.map(item => item.skillName)).toEqual(['create-docs', 'review-docs'])
-    expect(result.contributions.every(item => item.sourceKind === 'wellKnown')).toBe(true)
-    expect(result.contributions.every(item => item.resolver === 'wellKnownLegacy')).toBe(true)
-    expect(result.contributions[0]?.docsUrl).toBe('https://docus.dev/')
-    await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'references/templates.md'), 'utf8')).resolves.toBe('# Templates\n')
-    expect(defaultBranchMock).toHaveBeenCalledWith('nuxt-content/docus', 200)
-    expect(listGitHubDirectoryMock).not.toHaveBeenCalled()
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(fetchUrlJsonMock).toHaveBeenCalledTimes(1)
+    expect(fetchUrlJsonMock).toHaveBeenCalledWith('https://docs.example.com/.well-known/agent-skills/index.json', 200)
+  })
+
+  it('skips schema-less well-known indexes and falls back', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => url === 'https://docs.example.com/.well-known/agent-skills/index.json'
+        ? {
+            ok: true,
+            data: {
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  description: 'Use the SDK docs.',
+                  files: ['SKILL.md'],
+                },
+              ],
+            },
+          }
+        : { ok: false, status: 404 }),
+      fetchUrlBytes: fetchUrlBytesMock,
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      description: 'Docs SDK.',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(result.skipped.some(entry => entry.reason === 'well-known index is missing a supported schema')).toBe(true)
+    expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
   it('resolves RFC well-known skill-md entries and verifies digests', async () => {
@@ -494,6 +503,58 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(result.contributions[0]?.sourceKind).toBe('wellKnown')
     expect(result.contributions[0]?.resolver).toBe('wellKnownRfc')
     await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'SKILL.md'), 'utf8')).resolves.toBe(skill)
+  })
+
+  it('skips RFC well-known skill-md entries with invalid digest formats and falls back', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => url === 'https://docs.example.com/.well-known/agent-skills/index.json'
+        ? {
+            ok: true,
+            data: {
+              $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  type: 'skill-md',
+                  description: 'Use the SDK docs.',
+                  url: '/.well-known/agent-skills/docs-sdk/SKILL.md',
+                  digest: 'sha256:not-valid',
+                },
+              ],
+            },
+          }
+        : { ok: false, status: 404 }),
+      fetchUrlBytes: fetchUrlBytesMock,
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('generated')
+    expect(result.skipped.some(entry => entry.reason === 'RFC well-known skill is missing a valid sha256 digest')).toBe(true)
+    expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
   it('skips RFC well-known skill-md entries with digest mismatches and falls back', async () => {
@@ -599,63 +660,6 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(result.contributions).toHaveLength(1)
     expect(result.contributions[0]?.sourceKind).toBe('generated')
     expect(result.skipped.some(entry => entry.reason === 'archive artifacts are not supported yet')).toBe(true)
-  })
-
-  it('rejects unsafe legacy well-known file paths and falls back', async () => {
-    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
-    const fetchUrlBytesMock = vi.fn(async () => ({ ok: true, data: Buffer.from(skillMarkdown('docs-sdk')) }))
-
-    vi.resetModules()
-    vi.doMock('../src/remote-fetch', () => ({
-      parseGitHubRepo: vi.fn(() => null),
-      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
-      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
-      listGitHubDirectory: vi.fn(async () => []),
-      fetchUrlJson: vi.fn(async (url: string) => {
-        if (url === 'https://docs.example.com/.well-known/agent-skills/index.json') {
-          return { ok: false, status: 404 }
-        }
-
-        if (url === 'https://docs.example.com/.well-known/skills/index.json') {
-          return {
-            ok: true,
-            data: {
-              skills: [
-                {
-                  name: 'docs-sdk',
-                  description: 'Use the SDK docs.',
-                  files: ['SKILL.md', '../secret.md'],
-                },
-              ],
-            },
-          }
-        }
-
-        return { ok: false, status: 404 }
-      }),
-      fetchUrlBytes: fetchUrlBytesMock,
-    }))
-    vi.doMock('giget', () => ({
-      downloadTemplate: mockDownloadTemplate(async () => {
-        throw new Error('not found')
-      }),
-    }))
-
-    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
-    const result = await resolveRemoteContributionsForPackage({
-      packageName: 'docs-sdk',
-      version: '1.0.0',
-      homepage: 'https://docs.example.com/',
-    }, {
-      cacheRoot,
-      githubLookupTimeoutMs: 200,
-      enableGithubLookup: true,
-    })
-
-    expect(result.contributions).toHaveLength(1)
-    expect(result.contributions[0]?.sourceKind).toBe('generated')
-    expect(result.skipped.some(entry => entry.reason.includes('unsafe file path'))).toBe(true)
-    expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
   it('discovers all root github skills for docus', async () => {


### PR DESCRIPTION
## Summary

- add docs `.well-known` discovery for module skills using the Agent Skills Discovery v0.2 `agent-skills` index
- require v0.2 indexes to declare `$schema`, `type`, `url`, and `digest`, with same-origin artifact fetching and SHA-256 verification
- split package overrides from GitHub-only overrides and add Docus docs URL resolution for future v0.2 docs discovery
- render docs-discovered module skills in a separate generated guidance group

## Notes

- schema-less v0.1 `.well-known/skills` indexes are intentionally unsupported
- archive artifacts are discovered but skipped until archive extraction is implemented
- Nuxt 5 compatibility work is intentionally out of scope for this PR

## Validation

- `pnpm exec vitest run test/remote-resolver.test.ts test/core-content.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
