### PR TITLE
[codex] add hosted Nuxt skill and Doctor CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,19 @@
 
 ## Install
 
+For agents:
+
 ```bash
-npx nuxt module add nuxt-skill-hub
+npx skills add https://nuxt-skill.onmax.me/
 ```
+
+For Nuxt projects:
+
+```bash
+npx nuxi module add nuxt-skill-hub
+```
+
+Use [Doctor](https://vite-doctor.onmax.me/) to check AI-written Nuxt changes for Nuxt, Vue, Nitro, and Vite issues before review.
 
 ## License
 

--- a/docs/app/components/CoreGrid.vue
+++ b/docs/app/components/CoreGrid.vue
@@ -5,7 +5,7 @@ import { coreSkills } from '~/data/core-skills'
 <template>
   <section id="skills" class="relative scroll-mt-16 py-24 sm:py-32">
     <UContainer>
-      <div class="mx-auto mb-16 max-w-2xl text-center">
+      <div class="mx-auto mb-16 max-w-2xl text-left sm:text-center">
         <p class="mb-3 font-mono text-xs font-medium uppercase tracking-widest text-primary">What's inside</p>
         <h2 class="text-3xl font-bold text-highlighted sm:text-4xl">What your agent learns</h2>
         <p class="mt-4 text-lg text-muted leading-relaxed">

--- a/docs/app/components/DocsSection.vue
+++ b/docs/app/components/DocsSection.vue
@@ -36,7 +36,7 @@ const { copy, copied } = useClipboard({ copiedDuring: 2000 })
 <template>
   <section id="docs" class="relative scroll-mt-16 py-24 sm:py-32">
     <UContainer>
-      <div class="mx-auto mb-16 max-w-2xl text-center">
+      <div class="mx-auto mb-16 max-w-2xl text-left sm:text-center">
         <p class="mb-3 font-mono text-xs font-medium uppercase tracking-widest text-primary">Configuration</p>
         <h2 class="text-3xl font-bold text-highlighted sm:text-4xl">Configure it when you need control</h2>
         <p class="mt-4 text-lg text-muted leading-relaxed">

--- a/docs/app/components/DoctorSection.vue
+++ b/docs/app/components/DoctorSection.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import { motion } from 'motion-v'
+
+const doctorChecks = [
+  {
+    icon: 'i-lucide-stethoscope',
+    label: 'Hydration',
+  },
+  {
+    icon: 'i-lucide-lock-keyhole',
+    label: 'Runtime config',
+  },
+  {
+    icon: 'i-lucide-zap',
+    label: 'Nitro + Vite',
+  },
+] as const
+</script>
+
+<template>
+  <section
+    id="doctor"
+    class="relative scroll-mt-16 py-24 sm:py-32"
+  >
+    <UContainer>
+      <motion.div
+        :initial="{ opacity: 0, y: 28 }"
+        :while-in-view="{ opacity: 1, y: 0 }"
+        :viewport="{ once: true, amount: 0.2 }"
+        :transition="{ duration: 0.5 }"
+        class="grid items-start gap-10 border-t border-default pt-16 lg:grid-cols-[minmax(0,0.82fr)_minmax(520px,1.18fr)] lg:gap-16"
+      >
+        <div class="min-w-0">
+          <p class="mb-3 font-mono text-xs font-medium uppercase tracking-widest text-primary">
+            Doctor
+          </p>
+          <h2 class="max-w-xl text-3xl font-semibold tracking-tight text-highlighted text-balance sm:text-4xl">
+            Check AI-written Nuxt changes.
+          </h2>
+          <p class="mt-4 max-w-xl text-base/7 text-muted sm:text-lg/8">
+            Skill Hub teaches the agent before it edits. Doctor verifies the result before review.
+          </p>
+
+          <div class="mt-7 flex flex-wrap gap-2.5">
+            <div
+              v-for="check in doctorChecks"
+              :key="check.label"
+              class="inline-flex items-center gap-2 rounded-lg border border-default bg-muted px-3 py-2 text-sm font-medium text-muted"
+            >
+              <UIcon
+                :name="check.icon"
+                class="size-4 text-amber-600 dark:text-amber-400"
+                aria-hidden="true"
+              />
+              <span>{{ check.label }}</span>
+            </div>
+          </div>
+
+          <div class="mt-7 flex flex-wrap items-center gap-3">
+            <UButton
+              to="https://vite-doctor.onmax.me/"
+              target="_blank"
+              color="neutral"
+              variant="soft"
+              trailing-icon="i-lucide-arrow-up-right"
+            >
+              Open Doctor
+            </UButton>
+            <UButton
+              to="https://vite-doctor.onmax.me/.well-known/skills/doctor/SKILL.md"
+              target="_blank"
+              color="neutral"
+              variant="ghost"
+              trailing-icon="i-lucide-file-text"
+            >
+              View Doctor skill
+            </UButton>
+          </div>
+        </div>
+
+        <div class="min-w-0 overflow-hidden rounded-xl border border-default bg-[#0b0b0b] shadow-lg shadow-neutral-950/10 dark:shadow-black/30">
+          <div class="flex items-center gap-2 border-b border-white/[0.08] bg-white/[0.03] px-4 py-2.5">
+            <span class="size-2.5 rounded-full bg-red-400/70" />
+            <span class="size-2.5 rounded-full bg-yellow-400/70" />
+            <span class="size-2.5 rounded-full bg-green-400/70" />
+            <span class="ml-2 truncate font-mono text-xs text-neutral-500">~/your-nuxt-app</span>
+            <span class="ml-auto hidden font-mono text-xs text-neutral-500 sm:inline">vite-doctor</span>
+          </div>
+          <div class="min-h-[24rem] space-y-3 px-4 py-4 font-mono text-sm text-neutral-300 sm:px-5 sm:py-5 lg:min-h-[27rem]">
+            <p class="flex items-start gap-2">
+              <span class="select-none text-emerald-400/90">$</span>
+              <span class="min-w-0 break-words text-neutral-100">pnpm dlx vite-doctor . --rules nuxt/hydration</span>
+            </p>
+            <div class="space-y-2 border-t border-white/[0.08] pt-3 text-xs text-neutral-500">
+              <p>loaded nuxt.config.ts</p>
+              <p>scanned 38 Vue components</p>
+              <p>matched 15 framework rules</p>
+            </div>
+            <div class="space-y-4 border-t border-white/[0.08] pt-3">
+              <div class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-2 gap-y-0.5">
+                <UIcon
+                  name="i-lucide-triangle-alert"
+                  class="mt-1 size-3.5 text-amber-300"
+                  aria-hidden="true"
+                />
+                <div class="min-w-0">
+                  <p class="break-words font-medium text-neutral-100">
+                    nuxt/hydration/no-client-conditional-in-template
+                  </p>
+                  <p class="break-words text-xs text-neutral-500">
+                    app/components/UserMenu.vue:18:5
+                  </p>
+                  <p class="mt-1 break-words text-xs text-neutral-400">
+                    Browser-only state changes the server-rendered markup.
+                  </p>
+                </div>
+              </div>
+              <div class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-2 gap-y-0.5">
+                <UIcon
+                  name="i-lucide-circle-alert"
+                  class="mt-1 size-3.5 text-rose-300"
+                  aria-hidden="true"
+                />
+                <div class="min-w-0">
+                  <p class="break-words font-medium text-neutral-100">
+                    nuxt/runtime/no-secret-in-public-config
+                  </p>
+                  <p class="break-words text-xs text-neutral-500">
+                    nuxt.config.ts:42:13
+                  </p>
+                  <p class="mt-1 break-words text-xs text-neutral-400">
+                    Move private keys out of public runtime config.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="space-y-2 border-t border-white/[0.08] pt-3 text-xs text-neutral-500">
+              <p class="text-neutral-300">suggested agent action</p>
+              <p class="break-words">Apply the narrow fix, rerun Doctor, and keep the report with the PR.</p>
+            </div>
+            <div class="flex flex-wrap items-center gap-x-2.5 gap-y-1 border-t border-white/[0.08] pt-3 text-xs text-neutral-500">
+              <span class="font-medium text-neutral-200">2 high</span>
+              <span class="text-neutral-700" aria-hidden="true">/</span>
+              <span>13 warnings</span>
+              <span class="text-neutral-700" aria-hidden="true">/</span>
+              <span class="inline-flex items-center gap-1 text-emerald-300/90">
+                <UIcon
+                  name="i-lucide-file-search"
+                  class="size-3.5"
+                  aria-hidden="true"
+                />
+                report ready
+              </span>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </UContainer>
+  </section>
+</template>

--- a/docs/app/components/GeminiEffect.vue
+++ b/docs/app/components/GeminiEffect.vue
@@ -37,7 +37,7 @@ const centerPulse = ref(false)
 const connectedIcons = ref<{ iconUrl: string }[]>([])
 const containerOpacity = ref(1)
 
-const centerCommand = 'npx nuxt module add nuxt-skill-hub'
+const centerCommand = 'npx skills add https://nuxt-skill.onmax.me/'
 
 const center = { x: 50, y: 50 }
 

--- a/docs/app/components/Hero.vue
+++ b/docs/app/components/Hero.vue
@@ -28,18 +28,18 @@ defineOptions({
       :ui="{
         root: 'min-h-screen',
         container: 'flex min-h-screen flex-col gap-14 pt-32 pb-20 sm:gap-y-20 sm:pt-40 sm:pb-24 lg:pt-48 lg:pb-32',
-        wrapper: 'mx-auto w-full max-w-5xl text-center',
+        wrapper: 'mx-auto w-full max-w-5xl text-left sm:text-center',
         header: 'mx-auto max-w-4xl',
-        footer: 'mt-10 flex flex-col items-center gap-8',
+        footer: 'mt-10 flex flex-col items-start gap-8 sm:items-center',
       }"
     >
       <template #header>
-        <div class="flex flex-col items-center">
+        <div class="flex flex-col items-start sm:items-center">
           <motion.div
             :initial="{ opacity: 0, y: 20 }"
             :animate="{ opacity: 1, y: 0 }"
             :transition="{ duration: 0.5 }"
-            class="mb-6 flex flex-col items-center gap-3"
+            class="mb-6 flex flex-col items-start gap-3 sm:items-center"
           >
             <UBadge
               color="neutral"
@@ -62,7 +62,7 @@ defineOptions({
             :initial="{ opacity: 0, y: 20 }"
             :animate="{ opacity: 1, y: 0 }"
             :transition="{ duration: 0.5, delay: 0.1 }"
-            class="max-w-4xl text-center text-5xl font-bold leading-[0.92] tracking-tight text-highlighted text-balance sm:text-7xl"
+            class="max-w-4xl text-left text-5xl font-bold leading-[0.92] tracking-tight text-highlighted text-balance sm:text-center sm:text-7xl"
           >
             Teach your AI agent<br>
             <span class="text-primary">The Nuxt way.</span>
@@ -72,9 +72,9 @@ defineOptions({
             :initial="{ opacity: 0, y: 20 }"
             :animate="{ opacity: 1, y: 0 }"
             :transition="{ duration: 0.5, delay: 0.2 }"
-            class="mt-6 max-w-2xl text-center text-lg leading-relaxed text-muted sm:text-xl"
+            class="mt-6 max-w-2xl text-left text-lg leading-relaxed text-muted sm:text-center sm:text-xl"
           >
-            Install one module. Your agent gets Nuxt best practices, module APIs, and project-specific guidance before it changes your code.
+            Install one skill or module. Your agent gets Nuxt best practices, module APIs, and project-specific guidance before it changes your code.
           </motion.p>
         </div>
       </template>
@@ -84,8 +84,20 @@ defineOptions({
           :initial="{ opacity: 0, y: 20 }"
           :animate="{ opacity: 1, y: 0 }"
           :transition="{ duration: 0.5, delay: 0.3 }"
+          class="flex w-full flex-col items-start gap-3 sm:items-center"
         >
           <InstallCommand />
+          <UButton
+            to="https://vite-doctor.onmax.me/"
+            target="_blank"
+            color="neutral"
+            variant="link"
+            size="sm"
+            trailing-icon="i-lucide-arrow-up-right"
+            :ui="{ trailingIcon: 'size-3' }"
+          >
+            Check AI-written Nuxt changes with Doctor.
+          </UButton>
         </motion.div>
 
         <AgentLogos />

--- a/docs/app/components/InstallCommand.vue
+++ b/docs/app/components/InstallCommand.vue
@@ -1,22 +1,257 @@
 <script setup lang="ts">
-const command = 'npx nuxt module add nuxt-skill-hub'
-const { copy, copied } = useClipboard({ copiedDuring: 2000 })
+const commandTabs = [
+  {
+    label: 'For agents',
+    value: 'agents',
+    icon: 'i-lucide-bot',
+  },
+  {
+    label: 'For humans',
+    value: 'humans',
+    icon: 'i-lucide-user',
+  },
+] as const
+
+const packageManagers = [
+  {
+    label: 'pnpm',
+    value: 'pnpm',
+    icon: 'i-simple-icons-pnpm',
+    moduleCommand: 'pnpm dlx nuxi module add nuxt-skill-hub',
+  },
+  {
+    label: 'npm',
+    value: 'npm',
+    icon: 'i-simple-icons-npm',
+    moduleCommand: 'npx nuxi module add nuxt-skill-hub',
+  },
+  {
+    label: 'bun',
+    value: 'bun',
+    icon: 'i-simple-icons-bun',
+    moduleCommand: 'bunx nuxi module add nuxt-skill-hub',
+  },
+  {
+    label: 'yarn',
+    value: 'yarn',
+    icon: 'i-simple-icons-yarn',
+    moduleCommand: 'yarn dlx nuxi module add nuxt-skill-hub',
+  },
+] as const
+
+type CommandTab = (typeof commandTabs)[number]['value']
+type PackageManager = (typeof packageManagers)[number]['value']
+
+const activeCommandTab = shallowRef<CommandTab>('agents')
+const activePackageManager = shallowRef<PackageManager>('pnpm')
+const copiedCommand = shallowRef<string | null>(null)
+const selectedPackageManager = computed(
+  () =>
+    packageManagers.find(manager => manager.value === activePackageManager.value)
+    ?? packageManagers[0],
+)
+const skillsCommand = 'npx skills add https://nuxt-skill.onmax.me/'
+const activeCommand = computed(() =>
+  activeCommandTab.value === 'agents'
+    ? skillsCommand
+    : selectedPackageManager.value.moduleCommand,
+)
+const isCopied = computed(() => copiedCommand.value === activeCommand.value)
+const copyLabel = computed(() => isCopied.value ? 'Copied command' : 'Copy command')
+const { copy } = useClipboard({ copiedDuring: 1500 })
+
+let copiedTimeout: ReturnType<typeof setTimeout> | undefined
+
+async function copyActiveCommand() {
+  await copy(activeCommand.value)
+  copiedCommand.value = activeCommand.value
+  if (copiedTimeout) clearTimeout(copiedTimeout)
+  copiedTimeout = setTimeout(() => {
+    if (copiedCommand.value === activeCommand.value) {
+      copiedCommand.value = null
+    }
+  }, 1500)
+}
+
+watch([activePackageManager, activeCommandTab], () => {
+  copiedCommand.value = null
+})
+
+onUnmounted(() => {
+  if (copiedTimeout) clearTimeout(copiedTimeout)
+})
 </script>
 
 <template>
-  <div
-    class="group relative inline-flex items-center gap-3 rounded-lg border border-default bg-muted px-4 py-2.5 font-mono text-sm backdrop-blur-sm transition-colors hover:border-accented"
-    role="button"
-    tabindex="0"
-    @click="copy(command)"
-    @keydown.enter="copy(command)"
-  >
-    <span class="text-dimmed">$</span>
-    <span class="text-default">{{ command }}</span>
-    <UIcon
-      :name="copied ? 'i-lucide-check' : 'i-lucide-copy'"
-      :class="copied ? 'text-primary' : 'text-dimmed group-hover:text-muted'"
-      class="size-4 transition-colors"
-    />
+  <div class="flex w-full max-w-2xl flex-col items-stretch gap-3">
+    <div class="flex w-full flex-wrap items-center justify-start gap-3">
+      <div
+        class="relative inline-grid grid-cols-2 gap-1 rounded-lg border border-default bg-muted p-1 text-sm"
+        role="tablist"
+        aria-label="Installation audience"
+      >
+        <span
+          class="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc((100%_-_0.75rem)/2)] rounded-md bg-default shadow-sm ring-1 ring-black/5 transition-transform duration-[360ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none dark:ring-white/10"
+          :style="{
+            transform: activeCommandTab === 'humans' ? 'translateX(calc(100% + 0.25rem))' : 'translateX(0)',
+          }"
+          aria-hidden="true"
+        />
+        <button
+          v-for="tab in commandTabs"
+          :key="tab.value"
+          type="button"
+          role="tab"
+          :aria-selected="activeCommandTab === tab.value"
+          class="relative z-10 inline-flex min-w-32 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 font-medium transition-[color,transform] duration-150 active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/35"
+          :class="
+            activeCommandTab === tab.value
+              ? 'text-highlighted'
+              : 'text-dimmed hover:text-muted'
+          "
+          @click="activeCommandTab = tab.value"
+        >
+          <UIcon
+            :name="tab.icon"
+            class="size-3.5 shrink-0"
+            aria-hidden="true"
+          />
+          <span>{{ tab.label }}</span>
+        </button>
+      </div>
+
+      <div
+        class="relative h-10 shrink-0"
+        :class="activeCommandTab === 'humans' ? 'w-[13rem]' : 'w-0'"
+        role="radiogroup"
+        aria-label="Package manager"
+        :aria-hidden="activeCommandTab !== 'humans'"
+      >
+        <div
+          class="absolute top-0 right-0 flex items-center gap-1 rounded-lg border border-default bg-muted p-1 text-sm transition-[opacity,transform,filter] duration-[260ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
+          :class="
+            activeCommandTab === 'humans'
+              ? 'translate-y-0 opacity-100'
+              : 'pointer-events-none translate-y-2 opacity-0 blur-[1px]'
+          "
+          :aria-hidden="activeCommandTab !== 'humans'"
+        >
+          <button
+            v-for="manager in packageManagers"
+            :key="manager.value"
+            type="button"
+            role="radio"
+            :tabindex="activeCommandTab === 'humans' ? 0 : -1"
+            :aria-checked="activePackageManager === manager.value"
+            :aria-label="manager.label"
+            class="inline-flex h-8 min-w-8 items-center justify-center overflow-hidden rounded-md font-medium transition-[width,color,transform,background-color,box-shadow] duration-[220ms] ease-out active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/35 motion-reduce:transition-none"
+            :class="
+              activePackageManager === manager.value
+                ? 'w-22 bg-default px-2.5 text-highlighted shadow-sm ring-1 ring-black/5 dark:ring-white/10'
+                : 'w-8 px-0 text-dimmed grayscale hover:text-muted'
+            "
+            @click="activePackageManager = manager.value"
+          >
+            <UIcon
+              :name="manager.icon"
+              class="size-3.5 shrink-0"
+              aria-hidden="true"
+            />
+            <span
+              class="overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin-left] duration-[180ms] ease-out motion-reduce:transition-none"
+              :class="
+                activePackageManager === manager.value
+                  ? 'ml-1.5 max-w-12 opacity-100'
+                  : 'ml-0 max-w-0 opacity-0'
+              "
+            >
+              {{ manager.label }}
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <UButton
+      type="button"
+      color="neutral"
+      variant="ghost"
+      :aria-label="copyLabel"
+      class="group inline-flex w-full items-center gap-1.5 rounded-lg border border-default bg-muted px-3 py-2.5 text-left font-mono text-sm backdrop-blur-sm transition-[border-color,background-color] duration-200 hover:border-accented hover:bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/35"
+      @click="copyActiveCommand"
+    >
+      <span
+        class="text-dimmed select-none"
+        aria-hidden="true"
+      >$</span>
+      <span class="relative block min-w-0 flex-1 overflow-hidden text-default">
+        <Transition
+          name="command-swap"
+          mode="out-in"
+        >
+          <code
+            :key="activeCommand"
+            class="block overflow-x-auto whitespace-nowrap py-0.5 [scrollbar-width:thin]"
+          >
+            {{ activeCommand }}
+          </code>
+        </Transition>
+      </span>
+      <span class="relative ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted transition-colors group-hover:bg-default">
+        <Transition
+          name="copy-icon"
+          mode="out-in"
+        >
+          <UIcon
+            :key="isCopied ? 'check' : 'copy'"
+            :name="isCopied ? 'i-lucide-check' : 'i-lucide-copy'"
+            class="size-3.5"
+            :class="isCopied ? 'text-primary' : ''"
+            aria-hidden="true"
+          />
+        </Transition>
+      </span>
+    </UButton>
   </div>
 </template>
+
+<style scoped>
+.command-swap-enter-active,
+.command-swap-leave-active {
+  transition:
+    opacity 180ms cubic-bezier(0.23, 1, 0.32, 1),
+    filter 180ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 180ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.command-swap-enter-from,
+.command-swap-leave-to {
+  opacity: 0;
+  filter: blur(1px);
+  transform: translateY(2px);
+}
+
+.copy-icon-enter-active,
+.copy-icon-leave-active {
+  transition:
+    opacity 200ms cubic-bezier(0.23, 1, 0.32, 1),
+    filter 200ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.copy-icon-enter-from,
+.copy-icon-leave-to {
+  opacity: 0;
+  filter: blur(1px);
+  transform: scale(0.5);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .command-swap-enter-active,
+  .command-swap-leave-active,
+  .copy-icon-enter-active,
+  .copy-icon-leave-active {
+    transition-duration: 0ms;
+  }
+}
+</style>

--- a/docs/app/components/OgImage/Home.satori.vue
+++ b/docs/app/components/OgImage/Home.satori.vue
@@ -68,10 +68,10 @@
           lineHeight: '1.1',
         }"
       >
-        <span :style="{ fontSize: '72px', fontWeight: '700', color: '#161616', letterSpacing: '-0.025em' }">
+        <span :style="{ fontSize: '72px', fontWeight: '700', color: '#161616', letterSpacing: '0' }">
           Teach your AI agent
         </span>
-        <span :style="{ fontSize: '72px', fontWeight: '700', color: '#00dc82', letterSpacing: '-0.025em' }">
+        <span :style="{ fontSize: '72px', fontWeight: '700', color: '#00dc82', letterSpacing: '0' }">
           The Nuxt way.
         </span>
       </div>
@@ -101,7 +101,7 @@
           fontWeight: '500',
         }"
       >
-        npx nuxt module add nuxt-skill-hub
+        npx skills add https://nuxt-skill.onmax.me/
       </div>
     </div>
   </div>

--- a/docs/app/components/Playground.vue
+++ b/docs/app/components/Playground.vue
@@ -16,14 +16,14 @@ watch(moduleAuthorMode, () => selectFile('SKILL.md'))
     class="relative scroll-mt-16 py-24 sm:py-32"
   >
     <UContainer>
-      <div class="mb-12 text-center">
+      <div class="mb-12 text-left sm:text-center">
         <p class="mb-3 font-mono text-xs font-medium uppercase tracking-widest text-primary">
           Playground
         </p>
         <h2 class="text-3xl font-bold text-highlighted sm:text-4xl">
           Inspect the generated skill
         </h2>
-        <p class="mx-auto mt-4 max-w-2xl text-lg text-muted">
+        <p class="mt-4 max-w-2xl text-lg text-muted sm:mx-auto">
           Toggle modules to see how the skill changes as your stack changes.
         </p>
       </div>

--- a/docs/app/components/ResolutionSteps.vue
+++ b/docs/app/components/ResolutionSteps.vue
@@ -14,6 +14,7 @@ const stages: PipelineStage[] = [
     steps: [
       { title: 'Find agent folders', detail: 'Claude, Cursor, Gemini, and Codex targets', icon: 'i-lucide-scan-search' },
       { title: 'Read your stack', detail: 'Nuxt modules, layers, and extra packages', icon: 'i-lucide-package-search' },
+      { title: 'Check .well-known paths', detail: 'Standard discovery for docs-published skills', icon: 'i-lucide-radar' },
     ],
   },
   {
@@ -45,10 +46,10 @@ const stages: PipelineStage[] = [
         :transition="{ duration: 0.5 }"
         class="mx-auto max-w-3xl"
       >
-        <div class="mb-12 text-center">
+        <div class="mb-12 text-left sm:text-center">
           <p class="mb-3 font-mono text-xs font-medium uppercase tracking-widest text-primary">Pipeline</p>
           <h2 class="text-3xl font-bold text-highlighted sm:text-4xl">How the skill gets built</h2>
-          <p class="mx-auto mt-4 max-w-xl text-base leading-relaxed text-muted sm:text-lg">
+          <p class="mt-4 max-w-xl text-base leading-relaxed text-muted sm:mx-auto sm:text-lg">
             On every <code class="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-sm text-primary">nuxi prepare</code>, nuxt-skill-hub scans your project, resolves the best available sources, and writes agent-ready files.
           </p>
         </div>

--- a/docs/app/components/SingleEntryPoint.vue
+++ b/docs/app/components/SingleEntryPoint.vue
@@ -189,8 +189,8 @@ const { stop: stopSectionObserver } = useIntersectionObserver(
       <div class="mx-auto grid max-w-5xl grid-cols-1 items-center gap-12 lg:grid-cols-2">
         <!-- Left: text -->
         <motion.div
-          :initial="{ opacity: 0, x: -20 }"
-          :whileInView="{ opacity: 1, x: 0 }"
+          :initial="{ opacity: 0, y: 20 }"
+          :whileInView="{ opacity: 1, y: 0 }"
           :viewport="{ once: true, amount: 0.3 }"
           :transition="{ duration: 0.5 }"
         >
@@ -235,8 +235,8 @@ const { stop: stopSectionObserver } = useIntersectionObserver(
 
         <!-- Right: animated conversation -->
         <motion.div
-          :initial="{ opacity: 0, x: 20 }"
-          :whileInView="{ opacity: 1, x: 0 }"
+          :initial="{ opacity: 0, y: 20 }"
+          :whileInView="{ opacity: 1, y: 0 }"
           :viewport="{ once: true, amount: 0.3 }"
           :transition="{ duration: 0.5, delay: 0.15 }"
         >

--- a/docs/app/composables/useNuxtModuleSearch.ts
+++ b/docs/app/composables/useNuxtModuleSearch.ts
@@ -9,6 +9,7 @@ export interface NuxtModuleResult {
   github?: string
   website?: string
   skillAvailability: SkillAvailability
+  skillName: string
   type: string
 }
 

--- a/docs/app/composables/usePlayground.ts
+++ b/docs/app/composables/usePlayground.ts
@@ -39,7 +39,7 @@ export function usePlayground() {
     enabled: module.skillAvailability !== 'unavailable' ? module.enabled : false,
   }))
 
-  const selectedModulesState = useLocalStorage<SelectedModule[]>('playground-modules-v2', defaults)
+  const selectedModulesState = useLocalStorage<SelectedModule[]>('playground-modules-v3', defaults)
   const moduleAuthorMode = useLocalStorage<boolean>('playground-module-author-mode', false)
 
   const { data: moduleCatalogData } = useFetch<{ modules: NuxtModuleResult[] }>('/api/nuxt-modules', {
@@ -77,26 +77,32 @@ export function usePlayground() {
 
   const { data: apiData } = useFetch('/api/skill-files')
 
-  // Module skill file cache — seeded from prerendered data, individual content fetched on demand
   const moduleFileCache = ref<Record<string, ModuleSkillCacheEntry>>({})
   const moduleFileContentLoading = ref<Set<string>>(new Set())
 
-  // Seed cache from prerendered moduleSkills in apiData
-  watch(apiData, (data) => {
-    const prerendered = (data as any)?.moduleSkills as Record<string, ModuleSkillCacheEntry> | undefined
-    if (!prerendered) return
-    const updated = { ...moduleFileCache.value }
-    for (const [moduleId, entry] of Object.entries(prerendered)) {
-      if (!updated[moduleId]) {
-        updated[moduleId] = { skillName: entry.skillName, rawBase: entry.rawBase, paths: entry.paths || [], files: entry.files || {} }
+  const moduleSkillCache = computed<Record<string, ModuleSkillCacheEntry>>(() => {
+    const prerendered = ((apiData.value as any)?.moduleSkills || {}) as Record<string, ModuleSkillCacheEntry>
+    const merged: Record<string, ModuleSkillCacheEntry> = { ...prerendered }
+
+    for (const [moduleId, entry] of Object.entries(moduleFileCache.value)) {
+      const base = merged[moduleId]
+      merged[moduleId] = {
+        skillName: entry.skillName || base?.skillName,
+        rawBase: entry.rawBase || base?.rawBase,
+        paths: entry.paths.length ? entry.paths : base?.paths || [],
+        files: {
+          ...(base?.files || {}),
+          ...entry.files,
+        },
       }
     }
-    moduleFileCache.value = updated
-  }, { immediate: true })
+
+    return merged
+  })
 
   async function fetchModuleFileContent(moduleId: string, filePath: string) {
     const cacheKey = `${moduleId}:${filePath}`
-    const moduleEntry = moduleFileCache.value[moduleId]
+    const moduleEntry = moduleSkillCache.value[moduleId]
     if (!moduleEntry || moduleEntry.files[filePath] || moduleFileContentLoading.value.has(cacheKey)) return
 
     moduleFileContentLoading.value = new Set([...moduleFileContentLoading.value, cacheKey])
@@ -104,12 +110,15 @@ export function usePlayground() {
       // Fetch directly from GitHub raw content (works in static deployments)
       const base = moduleEntry.rawBase || `${skillsRawBase}/${moduleEntry.skillName || moduleId}`
       const content = await $fetch<string>(`${base}/${filePath}`, { responseType: 'text' })
+      const cachedEntry = moduleFileCache.value[moduleId]
       if (typeof content === 'string') {
         moduleFileCache.value = {
           ...moduleFileCache.value,
           [moduleId]: {
-            ...moduleEntry,
-            files: { ...moduleEntry.files, [filePath]: content },
+            skillName: cachedEntry?.skillName || moduleEntry.skillName,
+            rawBase: cachedEntry?.rawBase || moduleEntry.rawBase,
+            paths: cachedEntry?.paths.length ? cachedEntry.paths : moduleEntry.paths,
+            files: { ...(cachedEntry?.files || {}), [filePath]: content },
           },
         }
       }
@@ -181,7 +190,7 @@ export function usePlayground() {
 
     const files: Record<string, SkillFile> = {}
     for (const module of selectedModules.value.filter(item => item.enabled && item.skillAvailability !== 'unavailable')) {
-      const { preview, moduleFiles, sourceHref } = getModulePreviewFiles(module, moduleFileCache.value[module.id])
+      const { preview, moduleFiles, sourceHref } = getModulePreviewFiles(module, moduleSkillCache.value[module.id])
       if (!preview || !moduleFiles) {
         continue
       }
@@ -208,7 +217,7 @@ export function usePlayground() {
 
     const lists: Record<string, string[]> = {}
     for (const module of selectedModules.value.filter(item => item.enabled && item.skillAvailability !== 'unavailable')) {
-      const { moduleFiles } = getModulePreviewFiles(module, moduleFileCache.value[module.id])
+      const { moduleFiles } = getModulePreviewFiles(module, moduleSkillCache.value[module.id])
       if (!moduleFiles) {
         continue
       }
@@ -223,7 +232,7 @@ export function usePlayground() {
       ? selectedModules.value
           .filter(module => module.enabled && module.skillAvailability !== 'unavailable')
           .map((module) => {
-            const { preview } = getModulePreviewFiles(module, moduleFileCache.value[module.id])
+            const { preview } = getModulePreviewFiles(module, moduleSkillCache.value[module.id])
             return preview
           })
           .filter((entry): entry is SkillModuleRenderEntry => Boolean(entry))
@@ -276,7 +285,7 @@ export function usePlayground() {
     if (mod.skillAvailability === 'unavailable') return
     if (selectedModulesState.value.some(m => m.packageName === mod.npm)) return
     selectedModulesState.value.push({
-      id: mod.name,
+      id: mod.skillName,
       packageName: mod.npm,
       label: mod.name,
       description: mod.description,

--- a/docs/app/data/modules.ts
+++ b/docs/app/data/modules.ts
@@ -35,9 +35,39 @@ export interface SelectedModule {
 }
 
 const baseModules: Array<Omit<SkillModule, 'skillAvailability'>> = [
-  { id: 'nuxt-ui', packageName: '@nuxt/ui', label: 'Nuxt UI', icon: 'i-skill-logos-nuxt-ui', color: 'text-green-400', defaultEnabled: true, moduleType: 'official' },
-  { id: 'nuxt-content', packageName: '@nuxt/content', label: 'Nuxt Content', icon: 'i-skill-logos-nuxt-content', color: 'text-green-400', defaultEnabled: true, moduleType: 'official' },
-  { id: 'nuxthub', packageName: '@nuxthub/core', label: 'NuxtHub', icon: 'i-skill-logos-nuxthub', color: 'text-yellow-400', defaultEnabled: false, moduleType: 'official' },
+  {
+    id: 'nuxt-ui',
+    packageName: '@nuxt/ui',
+    label: 'Nuxt UI',
+    icon: 'i-skill-logos-nuxt-ui',
+    color: 'text-green-400',
+    defaultEnabled: true,
+    moduleType: 'official',
+    repoUrl: 'https://github.com/nuxt/ui',
+    docsUrl: 'https://ui.nuxt.com',
+  },
+  {
+    id: 'nuxt-content',
+    packageName: '@nuxt/content',
+    label: 'Nuxt Content',
+    icon: 'i-skill-logos-nuxt-content',
+    color: 'text-green-400',
+    defaultEnabled: true,
+    moduleType: 'official',
+    repoUrl: 'https://github.com/nuxt/content',
+    docsUrl: 'https://content.nuxt.com',
+  },
+  {
+    id: 'nuxthub',
+    packageName: '@nuxthub/core',
+    label: 'NuxtHub',
+    icon: 'i-skill-logos-nuxthub',
+    color: 'text-yellow-400',
+    defaultEnabled: false,
+    moduleType: 'official',
+    repoUrl: 'https://github.com/nuxt-hub/core',
+    docsUrl: 'https://hub.nuxt.com',
+  },
 ]
 
 export const modules: SkillModule[] = baseModules.map(m => ({

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -2,6 +2,7 @@
   <div class="bg-default">
     <Hero />
     <SingleEntryPoint />
+    <DoctorSection />
     <CoreGrid />
     <Playground />
     <DocsSection />

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,12 +1,14 @@
+import { fileURLToPath } from 'node:url'
+
 export default defineNuxtConfig({
   modules: ['@nuxt/ui', '@vueuse/nuxt', 'motion-v/nuxt', '@nuxtjs/mdc'],
   app: {
     head: {
       title: 'nuxt-skill-hub — Teach your AI agent the Nuxt way.',
       meta: [
-        { name: 'description', content: 'Install one module. Your agent gets Nuxt best practices, module APIs, and project-specific guidance before it changes your code.' },
+        { name: 'description', content: 'Install one skill or module. Your agent gets Nuxt best practices, module APIs, and project-specific guidance before it changes your code.' },
         { property: 'og:title', content: 'nuxt-skill-hub — Teach your AI agent the Nuxt way.' },
-        { property: 'og:description', content: 'Install one module. Your agent gets Nuxt best practices, module APIs, and project-specific guidance before it changes your code.' },
+        { property: 'og:description', content: 'Install one skill or module. Your agent gets Nuxt best practices, module APIs, and project-specific guidance before it changes your code.' },
         { property: 'og:image', content: 'https://nuxt-skill.onmax.me/og-image.png' },
         { property: 'og:type', content: 'website' },
         { name: 'twitter:card', content: 'summary_large_image' },
@@ -20,6 +22,11 @@ export default defineNuxtConfig({
         { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap' },
       ],
     },
+  },
+  nitro: {
+    publicAssets: [
+      { dir: fileURLToPath(new URL('./skills', import.meta.url)), baseURL: '/.well-known/skills' },
+    ],
   },
   css: ['~/assets/css/main.css'],
   colorMode: { preference: 'system' },

--- a/docs/server/api/nuxt-modules.get.ts
+++ b/docs/server/api/nuxt-modules.get.ts
@@ -1,5 +1,6 @@
 import { getSkillFolders, resolveSkillFolder } from '../utils/skill-discovery'
 import type { SkillAvailability } from '../../app/data/skill-packages'
+import { resolveMetadataRouterSkillName } from '~~/shared/skill-preview'
 
 interface NuxtApiModule {
   name: string
@@ -23,6 +24,7 @@ export interface NuxtModuleResult {
   github?: string
   website?: string
   skillAvailability: SkillAvailability
+  skillName: string
   type: string
 }
 
@@ -30,10 +32,11 @@ let cachedModules: NuxtModuleResult[] | null = null
 let cachedAt = 0
 const CACHE_TTL = 1000 * 60 * 60 // 1 hour
 
-function resolveAvailability(npm: string, skillFolders: Set<string>, github?: string, website?: string): SkillAvailability {
-  if (resolveSkillFolder(npm, skillFolders)) return 'real'
-  if (github || website) return 'generated'
-  return 'unavailable'
+function resolveSkill(npm: string, skillFolders: Set<string>, github?: string, website?: string): { availability: SkillAvailability, skillName: string } {
+  const realSkillName = resolveSkillFolder(npm, skillFolders)
+  if (realSkillName) return { availability: 'real', skillName: realSkillName }
+  if (github || website) return { availability: 'generated', skillName: resolveMetadataRouterSkillName(npm) }
+  return { availability: 'unavailable', skillName: resolveMetadataRouterSkillName(npm) }
 }
 
 export default defineEventHandler(async () => {
@@ -46,18 +49,22 @@ export default defineEventHandler(async () => {
     getSkillFolders(),
   ])
 
-  cachedModules = data.modules.map(m => ({
-    name: m.name,
-    npm: m.npm,
-    description: m.description,
-    icon: m.icon,
-    downloads: m.stats?.downloads ?? 0,
-    stars: m.stats?.stars ?? 0,
-    github: m.github,
-    website: m.website,
-    skillAvailability: resolveAvailability(m.npm, skillFolders, m.github, m.website),
-    type: m.type,
-  }))
+  cachedModules = data.modules.map((m) => {
+    const resolved = resolveSkill(m.npm, skillFolders, m.github, m.website)
+    return {
+      name: m.name,
+      npm: m.npm,
+      description: m.description,
+      icon: m.icon,
+      downloads: m.stats?.downloads ?? 0,
+      stars: m.stats?.stars ?? 0,
+      github: m.github,
+      website: m.website,
+      skillAvailability: resolved.availability,
+      skillName: resolved.skillName,
+      type: m.type,
+    }
+  })
   cachedAt = Date.now()
 
   return { modules: cachedModules }

--- a/docs/skills/index.json
+++ b/docs/skills/index.json
@@ -1,0 +1,9 @@
+{
+  "skills": [
+    {
+      "name": "nuxt",
+      "description": "Use Nuxt Skill Hub guidance for Nuxt, Vue, Nitro, runtime config, hydration, data fetching, Nuxt UI, Nuxt Content, and installed Nuxt module work.",
+      "files": ["SKILL.md"]
+    }
+  ]
+}

--- a/docs/skills/nuxt/SKILL.md
+++ b/docs/skills/nuxt/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: nuxt
+description: "Use Nuxt Skill Hub guidance for Nuxt, Vue, Nitro, runtime config, page metadata, hydration, data fetching, Nuxt UI, Nuxt Content, and installed Nuxt module work."
+---
+
+# Nuxt
+
+## Quick Start
+
+Use this skill before changing a Nuxt project:
+
+```bash
+npx skills add https://nuxt-skill.onmax.me/
+```
+
+For project-specific module guidance, install the Nuxt module in the target app:
+
+```bash
+npx nuxi module add nuxt-skill-hub
+```
+
+Then run the project's prepare step so Skill Hub can generate the local agent skill tree.
+
+## Workflow
+
+1. Inspect the exact surface first: page, layout, component, composable, server route, plugin, module API, or config file.
+2. Choose the smallest Nuxt-owned abstraction before falling back to generic Vue or raw HTML.
+3. For initial render data, prefer Nuxt payload-backed loading with `useFetch` or `useAsyncData`.
+4. Keep browser-only APIs out of SSR paths unless the code is gated behind client-only execution.
+5. Keep secrets and privileged I/O behind server routes, server utilities, or runtime config private values.
+6. Use module-specific guidance only when an installed module owns the API, component, hook, or runtime behavior being edited.
+7. Verify the intended Nuxt behavior before finishing, not only the visible output.
+
+## Routing
+
+- Page metadata, canonical URLs, Open Graph, layouts, or middleware: use Nuxt page/head patterns.
+- Hydration warnings, time, randomness, browser globals, or client-only rendering: use hydration and SSR consistency guidance.
+- Runtime config, environment variables, API routes, Nitro handlers, caching, or request validation: use Nuxt server guidance.
+- Vue component structure, props, emits, composables, or reactivity after the Nuxt decision is settled: use Vue guidance.
+- Nuxt UI, Nuxt Content, NuxtHub, or other module APIs: start with the broad Nuxt rule, then apply module-specific docs or generated Skill Hub module guidance.
+
+## Links
+
+- Docs: https://nuxt-skill.onmax.me/
+- Source: https://github.com/onmax/nuxt-skill-hub
+- Nuxt best practices: https://github.com/onmax/nuxt-skill-hub/tree/main/nuxt-best-practices
+
+## Rules
+
+- Do not replace Nuxt-specific rules with generic framework advice when Nuxt owns the surface.
+- Do not assume a module API shape from memory when the installed version can differ.
+- Do not broaden edits beyond the reported Nuxt surface unless the user asks for broader cleanup.
+- Treat Skill Hub as execution guidance that complements official docs; it does not replace source or version-specific documentation.

--- a/shared/skill-render.ts
+++ b/shared/skill-render.ts
@@ -1,7 +1,7 @@
 import { PACKAGE_VERSION } from './package-info'
 
 export type SkillSourceKind = 'dist' | 'github' | 'wellKnown' | 'generated'
-export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'wellKnownV2' | 'metadataRouter'
+export type SkillResolverKind = 'agentsField' | 'githubHeuristic' | 'wellKnownV2' | 'wellKnownSkills' | 'metadataRouter'
 export type SkillTrustLevel = 'official' | 'community'
 
 export interface NuxtPackMetadata {

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -85,7 +85,7 @@ export interface GeneratedModuleEntry {
   docsUrl?: string
   official: boolean
   trustLevel: 'official' | 'community'
-  resolver: 'agentsField' | 'githubHeuristic' | 'wellKnownV2' | 'metadataRouter'
+  resolver: 'agentsField' | 'githubHeuristic' | 'wellKnownV2' | 'wellKnownSkills' | 'metadataRouter'
   wrapperPath?: string
 }
 

--- a/src/well-known-resolver.ts
+++ b/src/well-known-resolver.ts
@@ -10,6 +10,7 @@ import type { ResolvedContribution, SkillManifestSkipped, ValidationIssue } from
 
 const WELL_KNOWN_DISCOVERY_V2_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
 const WELL_KNOWN_DISCOVERY_V2_INDEX_PATH = '/.well-known/agent-skills/index.json'
+const WELL_KNOWN_SKILLS_INDEX_PATH = '/.well-known/skills/index.json'
 
 interface WellKnownV2SkillEntry {
   name?: unknown
@@ -20,6 +21,17 @@ interface WellKnownV2SkillEntry {
 }
 
 interface WellKnownV2Index {
+  $schema?: unknown
+  skills?: unknown
+}
+
+interface WellKnownSkillsEntry {
+  name?: unknown
+  description?: unknown
+  files?: unknown
+}
+
+interface WellKnownSkillsIndex {
   $schema?: unknown
   skills?: unknown
 }
@@ -193,6 +205,24 @@ function sha256(bytes: Uint8Array): string {
   return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
 }
 
+function normalizeSkillFilePath(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim().replaceAll('\\', '/')
+  if (!trimmed || trimmed.startsWith('/') || trimmed.includes('\0')) {
+    return null
+  }
+
+  const segments = trimmed.split('/')
+  if (segments.some(segment => !segment || segment === '.' || segment === '..')) {
+    return null
+  }
+
+  return trimmed
+}
+
 async function writeSkillFile(root: string, relativePath: string, bytes: Uint8Array): Promise<void> {
   const destination = join(root, relativePath)
   await ensureDir(dirname(destination))
@@ -205,7 +235,7 @@ function contributionFor(input: {
   skillName: string
   description?: string
   docsUrl: string
-  resolver: 'wellKnownV2'
+  resolver: 'wellKnownV2' | 'wellKnownSkills'
   indexUrl: string
 }): ResolvedContribution {
   const sourceRepo = parseGitHubRepo(input.packageInfo.repository)
@@ -225,6 +255,77 @@ function contributionFor(input: {
     resolver: input.resolver,
     forceIncludeScripts: true,
   }, input.targetDir, join(input.targetDir, '..'))
+}
+
+async function materializeSkillsIndexEntry(input: {
+  packageInfo: InstalledPackageInfo
+  entry: WellKnownSkillsEntry
+  indexUrl: string
+  docsUrl: string
+  cacheRoot: string
+  timeoutMs: number
+}): Promise<MaterializedSkill | null> {
+  const skillName = typeof input.entry.name === 'string' ? input.entry.name.trim() : ''
+  if (!isValidSkillName(skillName)) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName || 'entry', 'well-known skill name is invalid') }
+  }
+
+  const description = typeof input.entry.description === 'string' ? input.entry.description.trim() : ''
+  if (!description) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known skill is missing a description') }
+  }
+
+  if (!Array.isArray(input.entry.files)) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known skill is missing a files array') }
+  }
+
+  const files = [...new Set(input.entry.files.map(normalizeSkillFilePath).filter((file): file is string => Boolean(file)))]
+  if (!files.includes('SKILL.md')) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known skill must list SKILL.md') }
+  }
+
+  if (files.length !== input.entry.files.length) {
+    return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known skill includes an unsafe file path') }
+  }
+
+  const origin = new URL(input.docsUrl).origin
+  const targetDir = join(
+    input.cacheRoot,
+    'well-known',
+    'skills',
+    sanitizeSegment(origin),
+    sanitizeSegment(input.packageInfo.packageName),
+    sanitizeSegment(input.packageInfo.version || 'unknown'),
+    sanitizeSegment(skillName),
+  )
+
+  await emptyDir(targetDir)
+
+  for (const file of files) {
+    const fileUrl = resolveSameOriginUrl(`${skillName}/${file}`, new URL('./', input.indexUrl).toString())
+    if (!fileUrl) {
+      return { skipped: makeSkip(input.packageInfo.packageName, skillName, 'well-known skill file URL must stay on the discovery origin') }
+    }
+
+    const response = await fetchUrlBytes(fileUrl, input.timeoutMs)
+    if (!response.ok || !response.data) {
+      return { skipped: makeSkip(input.packageInfo.packageName, skillName, `failed to fetch well-known skill file ${file}`) }
+    }
+
+    await writeSkillFile(targetDir, file, response.data)
+  }
+
+  return {
+    contribution: contributionFor({
+      packageInfo: input.packageInfo,
+      targetDir,
+      skillName,
+      description,
+      docsUrl: input.docsUrl,
+      resolver: 'wellKnownSkills',
+      indexUrl: input.indexUrl,
+    }),
+  }
 }
 
 async function materializeV2Skill(input: {
@@ -301,6 +402,51 @@ async function materializeV2Skill(input: {
       indexUrl: input.indexUrl,
     }),
   }
+}
+
+async function resolveSkillsIndex(input: {
+  packageInfo: InstalledPackageInfo
+  index: WellKnownSkillsIndex
+  indexUrl: string
+  docsUrl: string
+  cacheRoot: string
+  timeoutMs: number
+}): Promise<RemoteResolveResult> {
+  const skipped: SkillManifestSkipped[] = []
+  const contributions: ResolvedContribution[] = []
+
+  if (!Array.isArray(input.index.skills)) {
+    return {
+      contributions: [],
+      issues: [],
+      skipped: [makeSkip(input.packageInfo.packageName, input.packageInfo.packageName, 'well-known skills index is missing a skills array')],
+    }
+  }
+
+  for (const rawEntry of input.index.skills) {
+    if (!rawEntry || typeof rawEntry !== 'object') {
+      skipped.push(makeSkip(input.packageInfo.packageName, 'entry', 'well-known skill entry must be an object'))
+      continue
+    }
+
+    const materialized = await materializeSkillsIndexEntry({
+      packageInfo: input.packageInfo,
+      entry: rawEntry as WellKnownSkillsEntry,
+      indexUrl: input.indexUrl,
+      docsUrl: input.docsUrl,
+      cacheRoot: input.cacheRoot,
+      timeoutMs: input.timeoutMs,
+    })
+
+    if (materialized?.contribution) {
+      contributions.push(materialized.contribution)
+    }
+    if (materialized?.skipped) {
+      skipped.push(materialized.skipped)
+    }
+  }
+
+  return { contributions, issues: [], skipped }
 }
 
 async function resolveV2Index(input: {
@@ -384,6 +530,13 @@ async function resolveIndex(input: {
     })
   }
 
+  if (new URL(input.indexUrl).pathname === WELL_KNOWN_SKILLS_INDEX_PATH && !index.$schema) {
+    return await resolveSkillsIndex({
+      ...input,
+      index,
+    })
+  }
+
   if (typeof index.$schema === 'string' && index.$schema) {
     return {
       contributions: [],
@@ -409,27 +562,33 @@ export async function resolveViaWellKnown(
   const issues: ValidationIssue[] = []
 
   for (const docsUrl of bases) {
-    const indexUrl = new URL(WELL_KNOWN_DISCOVERY_V2_INDEX_PATH, docsUrl).toString()
-    const result = await resolveIndex({
-      packageInfo,
-      indexUrl,
-      docsUrl,
-      cacheRoot,
-      timeoutMs,
-    })
+    const indexUrls = [
+      new URL(WELL_KNOWN_DISCOVERY_V2_INDEX_PATH, docsUrl).toString(),
+      new URL(WELL_KNOWN_SKILLS_INDEX_PATH, docsUrl).toString(),
+    ]
 
-    if (!result) {
-      continue
-    }
+    for (const indexUrl of indexUrls) {
+      const result = await resolveIndex({
+        packageInfo,
+        indexUrl,
+        docsUrl,
+        cacheRoot,
+        timeoutMs,
+      })
 
-    issues.push(...result.issues)
-    skipped.push(...result.skipped)
+      if (!result) {
+        continue
+      }
 
-    if (result.contributions.length) {
-      return {
-        contributions: result.contributions,
-        issues,
-        skipped,
+      issues.push(...result.issues)
+      skipped.push(...result.skipped)
+
+      if (result.contributions.length) {
+        return {
+          contributions: result.contributions,
+          issues,
+          skipped,
+        }
       }
     }
   }

--- a/test/remote-resolver.test.ts
+++ b/test/remote-resolver.test.ts
@@ -357,16 +357,9 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(fetchUrlBytesMock).not.toHaveBeenCalled()
   })
 
-  it('only probes well-known v2 discovery indexes', async () => {
+  it('probes v2 and Docus well-known discovery indexes', async () => {
     const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
-    const v1IndexUrl = `https://docs.example.com/.well-known/${'skills'}/index.json`
-    const fetchUrlJsonMock = vi.fn(async (url: string) => {
-      if (url === v1IndexUrl) {
-        throw new Error('legacy endpoint should not be fetched')
-      }
-
-      return { ok: false, status: 404 }
-    })
+    const fetchUrlJsonMock = vi.fn(async () => ({ ok: false, status: 404 }))
 
     vi.resetModules()
     vi.doMock('../src/remote-fetch', () => ({
@@ -397,8 +390,9 @@ describe('resolveRemoteContributionsForPackage', () => {
 
     expect(result.contributions).toHaveLength(1)
     expect(result.contributions[0]?.sourceKind).toBe('generated')
-    expect(fetchUrlJsonMock).toHaveBeenCalledTimes(1)
+    expect(fetchUrlJsonMock).toHaveBeenCalledTimes(2)
     expect(fetchUrlJsonMock).toHaveBeenCalledWith('https://docs.example.com/.well-known/agent-skills/index.json', 200)
+    expect(fetchUrlJsonMock).toHaveBeenCalledWith('https://docs.example.com/.well-known/skills/index.json', 200)
   })
 
   it('skips schema-less well-known indexes instead of treating them as legacy discovery', async () => {
@@ -449,6 +443,76 @@ describe('resolveRemoteContributionsForPackage', () => {
     expect(result.contributions[0]?.sourceKind).toBe('generated')
     expect(result.skipped.some(entry => entry.reason === 'well-known index is missing the v2 schema')).toBe(true)
     expect(fetchUrlBytesMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves Docus well-known skills indexes', async () => {
+    const cacheRoot = await fsp.mkdtemp(join(tmpdir(), 'skill-hub-remote-'))
+    const skill = skillMarkdown('docs-sdk', 'Use the SDK docs.')
+    const apiRef = '# API\n'
+
+    vi.resetModules()
+    vi.doMock('../src/remote-fetch', () => ({
+      parseGitHubRepo: vi.fn(() => null),
+      fetchGitHubDefaultBranch: vi.fn(async () => 'main'),
+      fetchGitHubFileText: vi.fn(async () => ({ ok: false, status: 404 })),
+      listGitHubDirectory: vi.fn(async () => []),
+      fetchUrlJson: vi.fn(async (url: string) => {
+        if (url === 'https://docs.example.com/.well-known/agent-skills/index.json') {
+          return { ok: false, status: 404 }
+        }
+
+        if (url === 'https://docs.example.com/.well-known/skills/index.json') {
+          return {
+            ok: true,
+            data: {
+              skills: [
+                {
+                  name: 'docs-sdk',
+                  description: 'Use the SDK docs.',
+                  files: ['SKILL.md', 'references/api.md'],
+                },
+              ],
+            },
+          }
+        }
+
+        return { ok: false, status: 404 }
+      }),
+      fetchUrlBytes: vi.fn(async (url: string) => {
+        if (url === 'https://docs.example.com/.well-known/skills/docs-sdk/SKILL.md') {
+          return { ok: true, data: Buffer.from(skill) }
+        }
+
+        if (url === 'https://docs.example.com/.well-known/skills/docs-sdk/references/api.md') {
+          return { ok: true, data: Buffer.from(apiRef) }
+        }
+
+        return { ok: false, status: 404 }
+      }),
+    }))
+    vi.doMock('giget', () => ({
+      downloadTemplate: mockDownloadTemplate(async () => {
+        throw new Error('not found')
+      }),
+    }))
+
+    const { resolveRemoteContributionsForPackage } = await import('../src/remote-resolver')
+    const result = await resolveRemoteContributionsForPackage({
+      packageName: 'docs-sdk',
+      version: '1.0.0',
+      description: 'Docs SDK.',
+      homepage: 'https://docs.example.com/',
+    }, {
+      cacheRoot,
+      githubLookupTimeoutMs: 200,
+      enableGithubLookup: true,
+    })
+
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.sourceKind).toBe('wellKnown')
+    expect(result.contributions[0]?.resolver).toBe('wellKnownSkills')
+    await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'SKILL.md'), 'utf8')).resolves.toBe(skill)
+    await expect(fsp.readFile(join(result.contributions[0]!.sourceDir, 'references/api.md'), 'utf8')).resolves.toBe(apiRef)
   })
 
   it('resolves well-known v2 skill-md entries and verifies digests', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 export default defineVitestConfig({
   test: {
     environment: 'node',
+    fileParallelism: false,
   },
 })


### PR DESCRIPTION
## Summary
- Add a Docus-compatible hosted Nuxt skill under docs/skills and expose it through /.well-known/skills.
- Replace the hero install pill with an agent/human command switcher and add subtle Doctor entry points.
- Fix playground module rendering by carrying resolved skill names and deriving module files from the prerendered skill payload.
- Run Vitest files sequentially because generation tests share fixture/cache directories.

## Validation
- pnpm lint
- pnpm run docs:typecheck
- pnpm test
- Browser verification against http://127.0.0.1:4321 for hero switcher, Doctor section, hosted skill endpoint, default module tree, and adding nuxt-seo.